### PR TITLE
Use net.JoinHostPort when appending ports.

### DIFF
--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -396,7 +396,7 @@ func _main() error {
 		return err
 	}
 	if _, _, err := net.SplitHostPort(*host); err != nil {
-		u.Host += ":" + port
+		u.Host = net.JoinHostPort(u.Host, port)
 	}
 	*host = u.String()
 


### PR DESCRIPTION
Fixes port appending for IPv6 addresses.