### PR TITLE
Update deps to pull in new logger.

### DIFF
--- a/dcrtimed/config.go
+++ b/dcrtimed/config.go
@@ -413,9 +413,9 @@ func loadConfig() (*config, []string, error) {
 		os.Exit(0)
 	}
 
-	// Initialize logging at the default logging level.
-	initSeelogLogger(filepath.Join(cfg.LogDir, defaultLogFilename))
-	setLogLevels(defaultLogLevel)
+	// Initialize log rotation.  After log rotation has been initialized, the
+	// logger variables may be used.
+	initLogRotator(filepath.Join(cfg.LogDir, defaultLogFilename))
 
 	// Parse, validate, and set debug log level(s).
 	if err := parseAndSetDebugLevels(cfg.DebugLevel); err != nil {

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -428,7 +428,11 @@ func _main() error {
 	if err != nil {
 		return fmt.Errorf("Could not load configuration file: %v", err)
 	}
-	defer backendLog.Flush()
+	defer func() {
+		if logRotator != nil {
+			logRotator.Close()
+		}
+	}()
 
 	var proxy bool
 	mode := "Store"

--- a/dcrtimed/log.go
+++ b/dcrtimed/log.go
@@ -6,20 +6,48 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/btcsuite/btclog"
-	"github.com/btcsuite/seelog"
+	"github.com/jrick/logrotate/rotator"
 )
 
-// Loggers per subsytem.  Note that backendLog is a seelog logger that all of
-// the subsystem loggers route their messages to.  When adding new subsystems,
-// add a reference here, to the subsystemLoggers map, and the useLogger
-// function.
+// logWriter implements an io.Writer that outputs to both standard output and
+// the write-end pipe of an initialized log rotator.
+type logWriter struct{}
+
+func (logWriter) Write(p []byte) (n int, err error) {
+	os.Stdout.Write(p)
+	logRotatorPipe.Write(p)
+	return len(p), nil
+}
+
+// Loggers per subsystem.  A single backend logger is created and all subsytem
+// loggers created from it will write to the backend.  When adding new
+// subsystems, add the subsystem logger variable here and to the
+// subsystemLoggers map.
+//
+// Loggers can not be used before the log rotator has been initialized with a
+// log file.  This must be performed early during application startup by calling
+// initLogRotator.
 var (
-	backendLog = seelog.Disabled
-	log        = btclog.Disabled
-	fsbeLog    = btclog.Disabled
+	// backendLog is the logging backend used to create all subsystem loggers.
+	// The backend must not be used before the log rotator has been initialized,
+	// or data races and/or nil pointer dereferences will occur.
+	backendLog = btclog.NewBackend(logWriter{})
+
+	// logRotator is one of the logging outputs.  It should be closed on
+	// application shutdown.
+	logRotator *rotator.Rotator
+
+	// logRotatorPipe is the write-end pipe for writing to the log rotator.  It
+	// is written to by the Write method of the logWriter type.
+	logRotatorPipe *io.PipeWriter
+
+	log     = backendLog.Logger("DCRT")
+	fsbeLog = backendLog.Logger("FSBE")
 )
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.
@@ -28,45 +56,27 @@ var subsystemLoggers = map[string]btclog.Logger{
 	"FSBE": fsbeLog,
 }
 
-// useLogger updates the logger references for subsystemID to logger.  Invalid
-// subsystems are ignored.
-func useLogger(subsystemID string, logger btclog.Logger) {
-	if _, ok := subsystemLoggers[subsystemID]; !ok {
-		return
-	}
-	subsystemLoggers[subsystemID] = logger
-
-	switch subsystemID {
-	case "DCRT":
-		log = logger
-	case "FSBE":
-		fsbeLog = logger
-	}
-}
-
-// initSeelogLogger initializes a new seelog logger that is used as the backend
-// for all logging subsytems.
-func initSeelogLogger(logFile string) {
-	config := `
-        <seelog type="adaptive" mininterval="2000000" maxinterval="100000000"
-                critmsgcount="500" minlevel="trace">
-                <outputs formatid="all">
-                        <console />
-                        <rollingfile type="size" filename="%s" maxsize="10485760" maxrolls="3" />
-                </outputs>
-                <formats>
-                        <format id="all" format="%%Time %%Date [%%LEV] %%Msg%%n" />
-                </formats>
-        </seelog>`
-	config = fmt.Sprintf(config, logFile)
-
-	logger, err := seelog.LoggerFromConfigAsString(config)
+// initLogRotator initializes the logging rotater to write logs to logFile and
+// create roll files in the same directory.  It must be called before the
+// package-global log rotater variables are used.
+func initLogRotator(logFile string) {
+	logDir, _ := filepath.Split(logFile)
+	err := os.MkdirAll(logDir, 0700)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create logger: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
+		os.Exit(1)
+	}
+	pr, pw := io.Pipe()
+	r, err := rotator.New(pr, logFile, 10*1024, false, 3)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
 		os.Exit(1)
 	}
 
-	backendLog = logger
+	go r.Run()
+
+	logRotator = r
+	logRotatorPipe = pw
 }
 
 // setLogLevel sets the logging level for provided subsystem.  Invalid
@@ -79,17 +89,8 @@ func setLogLevel(subsystemID string, logLevel string) {
 		return
 	}
 
-	// Default to info if the log level is invalid.
-	level, ok := btclog.LogLevelFromString(logLevel)
-	if !ok {
-		level = btclog.InfoLvl
-	}
-
-	// Create new logger for the subsystem if needed.
-	if logger == btclog.Disabled {
-		logger = btclog.NewSubsystemLogger(backendLog, subsystemID+": ")
-		useLogger(subsystemID, logger)
-	}
+	// Defaults to info if the log level is invalid.
+	level, _ := btclog.LevelFromString(logLevel)
 	logger.SetLevel(level)
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,18 @@
-hash: cd90cc268d9ceef6e276bfa7a615c5f85b5a27b0d917ee3f1f1e5d5598f2fa00
-updated: 2017-06-09T14:11:57.96775988-04:00
+hash: 38dd80858269877d2972fd1e13fc37cce7fa8df51cb51709a779cda93a68fead
+updated: 2017-06-20T13:20:30.5486935-04:00
 imports:
+- name: github.com/agl/ed25519
+  version: 278e1ec8e8a6e017cd07577924d6766039146ced
+  subpackages:
+  - edwards25519
 - name: github.com/btcsuite/btclog
-  version: 73889fb79bd687870312b6e40effcecffbd57d30
+  version: 30bef3d5a6b4600e2129de8b6527ffcc1ee397ca
 - name: github.com/btcsuite/go-flags
   version: 6c288d648c1cc1befcb90cb5511dcacf64ae8e61
-- name: github.com/btcsuite/seelog
-  version: ae8891d029dd3c269dcfd6f261ad23e761acd99f
 - name: github.com/decred/blake256
   version: a840e32d7c31fe2e0218607334cb120a683951a4
 - name: github.com/decred/dcrd
-  version: 0d48ca0105e0d512f89629e39ef841a4194c448b
+  version: ce4b77d3d9e3a4d3393e1fa3baeee5679cad518d
   subpackages:
   - chaincfg
   - chaincfg/chainec
@@ -21,18 +23,14 @@ imports:
   - txscript
   - wire
 - name: github.com/decred/dcrutil
-  version: ebd2e98736e819ac043d54439969b30144b92ced
+  version: a5fab53cab39b793142c8453caa4c6f83bc152d4
   subpackages:
   - base58
 - name: github.com/decred/dcrwallet
-  version: ae00abf404a5f62c91a26c70a9996c5ec57d18c3
+  version: 56954e8ce2d801e35d5df5524d32983268dc64c2
   subpackages:
   - netparams
   - rpc/walletrpc
-- name: github.com/decred/ed25519
-  version: b0909d3f798b97a03c9e77023f97a5301a2a7900
-  subpackages:
-  - edwards25519
 - name: github.com/golang/protobuf
   version: fec3b39b059c0f88fa6b20f5ed012b1aa203a8b4
   subpackages:
@@ -44,6 +42,10 @@ imports:
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
   version: bcd8bc72b08df0f70df986b97f95590779502d31
+- name: github.com/jrick/logrotate
+  version: 4ed05ed86ef17d10ff99cce77481e0fcf6f2c7b0
+  subpackages:
+  - rotator
 - name: github.com/robfig/cron
   version: b024fc5ea0e34bc3f83d9941c8d60b0622bfaca4
 - name: github.com/syndtr/goleveldb
@@ -62,11 +64,11 @@ imports:
   - leveldb/table
   - leveldb/util
 - name: golang.org/x/crypto
-  version: 0fe963104e9d1877082f8fb38f816fcd97eb1d10
+  version: adbae1b6b6fb4b02448a0fc0dbbc9ba2b95b294d
   subpackages:
   - ripemd160
 - name: golang.org/x/net
-  version: 513929065c19401a1c7b76ecd942f9f86a0c061b
+  version: fe686d45ea04bc1bd4eff6a52865ce8757320325
   subpackages:
   - context
   - http2
@@ -76,7 +78,7 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/text
-  version: 19e51611da83d6be54ddafce4a4af510cb3e9ea4
+  version: 4e9ab9ee170f2a39bd66c92b3e0a47ff47a4bc77
   subpackages:
   - secure/bidirule
   - transform

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,8 +2,6 @@ package: github.com/decred/dcrtime
 import:
 - package: github.com/btcsuite/btclog
 - package: github.com/btcsuite/go-flags
-- package: github.com/btcsuite/seelog
-  version: ^2.1.0
 - package: github.com/decred/dcrd
   subpackages:
   - chaincfg
@@ -28,6 +26,9 @@ import:
   subpackages:
   - credentials
   - grpclog
+- package: github.com/jrick/logrotate
+  subpackages:
+  - rotator
 testImport:
 - package: github.com/davecgh/go-spew
   subpackages:


### PR DESCRIPTION
Some of the commands appear to be logging by writing to standard
output directly using the fmt package.  These calls have not been
switched to use the new btclog logger but dcrtimed has been converted
from seelog to btclog.