### PR TITLE
Update deps to pull in additional logging changes.

### DIFF
--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -96,9 +96,6 @@ func (d *DcrtimeStore) sendToBackend(w http.ResponseWriter, route, contentType, 
 	if err != nil {
 		log.Errorf("Error responding to client: %v", err)
 	}
-
-	return
-
 }
 
 func (d *DcrtimeStore) proxyTimestamp(w http.ResponseWriter, r *http.Request) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,18 @@
 hash: 38dd80858269877d2972fd1e13fc37cce7fa8df51cb51709a779cda93a68fead
-updated: 2017-06-20T13:20:30.5486935-04:00
+updated: 2017-06-28T16:43:44.7760073-04:00
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
   subpackages:
   - edwards25519
 - name: github.com/btcsuite/btclog
-  version: 30bef3d5a6b4600e2129de8b6527ffcc1ee397ca
+  version: 84c8d2346e9fc8c7b947e243b9c24e6df9fd206a
 - name: github.com/btcsuite/go-flags
   version: 6c288d648c1cc1befcb90cb5511dcacf64ae8e61
 - name: github.com/decred/blake256
   version: a840e32d7c31fe2e0218607334cb120a683951a4
 - name: github.com/decred/dcrd
-  version: ce4b77d3d9e3a4d3393e1fa3baeee5679cad518d
+  version: 713164983204ef44185aa4cd6a48fed096188d46
   subpackages:
   - chaincfg
   - chaincfg/chainec
@@ -27,7 +27,7 @@ imports:
   subpackages:
   - base58
 - name: github.com/decred/dcrwallet
-  version: 56954e8ce2d801e35d5df5524d32983268dc64c2
+  version: fdc45f39a468305fa966b6c7407a7d813a3311ca
   subpackages:
   - netparams
   - rpc/walletrpc
@@ -43,7 +43,7 @@ imports:
 - name: github.com/gorilla/mux
   version: bcd8bc72b08df0f70df986b97f95590779502d31
 - name: github.com/jrick/logrotate
-  version: 4ed05ed86ef17d10ff99cce77481e0fcf6f2c7b0
+  version: a93b200c26cbae3bb09dd0dc2c7c7fe1468a034a
   subpackages:
   - rotator
 - name: github.com/robfig/cron
@@ -64,11 +64,11 @@ imports:
   - leveldb/table
   - leveldb/util
 - name: golang.org/x/crypto
-  version: adbae1b6b6fb4b02448a0fc0dbbc9ba2b95b294d
+  version: 84f24dfdf3c414ed893ca1b318d0045ef5a1f607
   subpackages:
   - ripemd160
 - name: golang.org/x/net
-  version: fe686d45ea04bc1bd4eff6a52865ce8757320325
+  version: 8663ed5da4fd087c3cfb99a996e628b72e2f0948
   subpackages:
   - context
   - http2
@@ -78,7 +78,7 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/text
-  version: 4e9ab9ee170f2a39bd66c92b3e0a47ff47a4bc77
+  version: 6353ef0f924300eea566d3438817aa4d3374817e
   subpackages:
   - secure/bidirule
   - transform


### PR DESCRIPTION
This update adds additional callsite logging options via btclog and
fixes an error with the rotator package that caused it to stop running
when creating any log messages larger than 4096 bytes.

While here, switch to the new Write method of the Rotator object as
this is more efficient than using the Reader interface with a pipe.