### PR TITLE
Multi: update the dcrutil imports after its move to dcrd

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -33,21 +33,21 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/decred/dcrd"
-  packages = ["chaincfg","chaincfg/chainec","chaincfg/chainhash","dcrec/edwards","dcrec/secp256k1","dcrec/secp256k1/schnorr","txscript","wire"]
-  revision = "ecf5f0a00e3ae1463f46b1c52d2a6a93fed8eb62"
+  name = "github.com/decred/base58"
+  packages = ["."]
+  revision = "b3520e187fa8ebe65eb74245408cf4b83e6a65d3"
 
 [[projects]]
   branch = "master"
-  name = "github.com/decred/dcrutil"
-  packages = [".","base58"]
-  revision = "ddbde93f65ab0692e54ed8a5ad325fa2e8af4daa"
+  name = "github.com/decred/dcrd"
+  packages = ["certgen","chaincfg","chaincfg/chainec","chaincfg/chainhash","dcrec/edwards","dcrec/secp256k1","dcrec/secp256k1/schnorr","dcrutil","txscript","wire"]
+  revision = "f903c700a41a80f59daf21fa8489a437485dcfdb"
 
 [[projects]]
   branch = "master"
   name = "github.com/decred/dcrwallet"
   packages = ["netparams","rpc/walletrpc"]
-  revision = "e3aa7eafac265c77c59cf7874307a1ea28b80ee0"
+  revision = "2df4002bce8c540907c9a3e2980fc3e5deeba8f6"
 
 [[projects]]
   branch = "master"
@@ -124,6 +124,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cc804564e8396f3f8e0f74225c2e664f1c76e39ccaf692ccf1bb5d137ba6f154"
+  inputs-digest = "c46a598946fae3261879bc6b775ecb51c9f8025eeb4fe2528b08b1855606a261"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,10 +17,6 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/decred/dcrutil"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/decred/dcrwallet"
 
 [[constraint]]

--- a/cmd/dcrtime_dumpdb/dcrtime_dumpdb.go
+++ b/cmd/dcrtime_dumpdb/dcrtime_dumpdb.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrtime/dcrtimed/backend/filesystem"
-	"github.com/decred/dcrutil"
 )
 
 var (

--- a/dcrtimed/config.go
+++ b/dcrtimed/config.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 
 	flags "github.com/btcsuite/go-flags"
-	"github.com/decred/dcrutil"
+	"github.com/decred/dcrd/dcrutil"
 )
 
 const (

--- a/util/cert.go
+++ b/util/cert.go
@@ -10,13 +10,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/decred/dcrutil"
+	"github.com/decred/dcrd/certgen"
 )
 
 // GenCertPair generates a key/cert pair to the paths provided.
 func GenCertPair(org, certFile, keyFile string) error {
 	validUntil := time.Now().Add(10 * 365 * 24 * time.Hour)
-	cert, key, err := dcrutil.NewTLSCertPair(elliptic.P521(), org,
+	cert, key, err := certgen.NewTLSCertPair(elliptic.P521(), org,
 		validUntil, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
Also:
    - update a NewTLSCertPair import (moved from dcrutil to certgen);
    - update the dep manifest and lock files.