### PR TITLE
Add option to set a single string digest on timestamp request

### DIFF
--- a/api/v1/v1.go
+++ b/api/v1/v1.go
@@ -84,8 +84,11 @@ type StatusReply struct {
 
 // Timestamp is used to ask the timestamp server to store a batch of digests.
 // ID is user settable and can be used as a unique identifier by the client.
+// Digest is a string for a single hash sent by a client. It is appended to
+// the digests array when processed by the backend.
 type Timestamp struct {
 	ID      string   `json:"id"`
+	Digest  string   `json:"digest"`
 	Digests []string `json:"digests"`
 }
 

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -224,7 +224,13 @@ func (d *DcrtimeStore) timestamp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate all digests.  If one is invalid return failure.
+	// If a single digest was set on the request, append it
+	// to the digests array
+	if t.Digest != "" {
+		t.Digests = append(t.Digests, t.Digest)
+	}
+
+	// Validate all digests. If one is invalid return failure.
 	digests, err := convertDigests(t.Digests)
 	if err != nil {
 		util.RespondWithError(w, http.StatusBadRequest,


### PR DESCRIPTION
This PR was motivated by the no-js version of dcrtimegui redesign. Form data can't be transformed into an array without scripting, so we need an option to send a single string hash to the timestamp route in the backend. This commit makes it possible to send request bodies of the following format:

```
{
  "digest": "0cb888fa05d77429066994aec46e79f23243bcd6eff9e891d2d25767beedb9e6",
  "digests": ["fa441a7ca6c25057936b32dec6083cc61078003c3907b4f32feabb5ccdb15371"]
}
```

```
{
  "digest": "0cb888fa05d77429066994aec46e79f23243bcd6eff9e891d2d25767beedb9e6"
}
```

```
{
  "digests": ["fa441a7ca6c25057936b32dec6083cc61078003c3907b4f32feabb5ccdb15371"]
}
```