### PR TITLE
Add config to json decoder

### DIFF
--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -218,6 +218,7 @@ func (d *DcrtimeStore) timestamp(w http.ResponseWriter, r *http.Request) {
 
 	var t v1.Timestamp
 	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&t); err != nil {
 		util.RespondWithError(w, http.StatusBadRequest,
 			"Invalid request payload")
@@ -296,6 +297,7 @@ func (d *DcrtimeStore) verify(w http.ResponseWriter, r *http.Request) {
 
 	var v v1.Verify
 	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&v); err != nil {
 		util.RespondWithError(w, http.StatusBadRequest,
 			"Invalid request payload")


### PR DESCRIPTION
Right now, the code is processing requests with unknown json fields that are not specified by the API. `DisallowUnknownFields()` makes the decoder error out when this happens.

Example of bad request to timestamp:

```
{ random_field_name: "random value"} 
```

response: 
```
{
    "id": "",
    "servertimestamp": 1575118800,
    "digests": null,
    "results": []
}
```

It should error out with `Invalid request payload`. This PR fixes this.