### PR TITLE
[api-v2] Add routes for API v2

### DIFF
--- a/api/v1/v1.go
+++ b/api/v1/v1.go
@@ -13,17 +13,21 @@ import (
 // XXX add a clamp to all batches
 
 const (
+	APIVersion = 1
+
+	RoutePrefix = "/v1/"
+
 	// StatusRoute defines the API route for retrieving
 	// the server status.
-	StatusRoute = "/v1/status/"
+	StatusRoute = RoutePrefix + "status/"
 
 	// TimestampRoute defines the API route for submitting
 	// both timestamps and digests.
-	TimestampRoute = "/v1/timestamp/"
+	TimestampRoute = RoutePrefix + "timestamp/"
 
 	// VerifyRoute defines the API route for both timestamp
 	// and digest verification.
-	VerifyRoute = "/v1/verify/" // Multi verify ingest
+	VerifyRoute = RoutePrefix + "verify/" // Multi verify ingest
 
 	// WalletBalanceRoute defines the API route for retrieving
 	// the account balance from dcrtimed's wallet instance

--- a/api/v1/v1.go
+++ b/api/v1/v1.go
@@ -17,24 +17,6 @@ const (
 	// APIVersion defines the version number for this code.
 	APIVersion = 1
 
-	RoutePrefix = "/v1/"
-
-	// StatusRoute defines the API route for retrieving
-	// the server status.
-	StatusRoute = RoutePrefix + "status/"
-
-	// TimestampRoute defines the API route for submitting
-	// both timestamps and digests.
-	TimestampRoute = RoutePrefix + "timestamp/"
-
-	// VerifyRoute defines the API route for both timestamp
-	// and digest verification.
-	VerifyRoute = RoutePrefix + "verify/" // Multi verify ingest
-
-	// WalletBalanceRoute defines the API route for retrieving
-	// the account balance from dcrtimed's wallet instance
-	WalletBalanceRoute = "/v1/balance"
-
 	// ResultOK indicates the operation completed successfully.
 	ResultOK = 0
 
@@ -81,6 +63,10 @@ var (
 	// VerifyRoute defines the API route for both timestamp
 	// and digest verification.
 	VerifyRoute = RoutePrefix + "/verify/" // Multi verify digest
+
+	// WalletBalanceRoute defines the API route for retrieving
+	// the account balance from dcrtimed's wallet instance
+	WalletBalanceRoute = RoutePrefix + "/balance"
 
 	// Result defines legible string messages to a timestamping/query
 	// result code.

--- a/api/v1/v1.go
+++ b/api/v1/v1.go
@@ -5,6 +5,7 @@
 package v1
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/decred/dcrtime/merkle"
@@ -13,6 +14,7 @@ import (
 // XXX add a clamp to all batches
 
 const (
+	// APIVersion defines the version number for this code.
 	APIVersion = 1
 
 	RoutePrefix = "/v1/"
@@ -65,6 +67,23 @@ const (
 )
 
 var (
+	// RoutePrefix is the route url prefix for this version.
+	RoutePrefix = fmt.Sprintf("/v%v", APIVersion)
+
+	// StatusRoute defines the API route for retrieving
+	// the server status.
+	StatusRoute = RoutePrefix + "/status/"
+
+	// TimestampRoute defines the API route for submitting
+	// both timestamps and digests.
+	TimestampRoute = RoutePrefix + "/timestamp/"
+
+	// VerifyRoute defines the API route for both timestamp
+	// and digest verification.
+	VerifyRoute = RoutePrefix + "/verify/" // Multi verify digest
+
+	// Result defines legible string messages to a timestamping/query
+	// result code.
 	Result = map[int]string{
 		ResultOK:               "OK",
 		ResultExistsError:      "Exists",

--- a/api/v2/api.md
+++ b/api/v2/api.md
@@ -87,8 +87,8 @@ Reply:
 
 #### `Timestamps`
 
-Upload multiple digests to the time server. Behaves the same as /v2/timestamp, except for the hability to send multiple
-hashes in a single request.
+Upload multiple digests to the time server. Behaves the same as /v2/timestamp, except for the ability to send multiple
+digests in a single request.
 
 * **URL**
 
@@ -160,7 +160,7 @@ Reply:
 
 #### `Verify`
 
-Verifies the status of a batch of digests or timestamps on the server. If verifying a digest, it'll return the chain information relative to that digest, including its merkle path. If verifying a timestamp, it'll return the collection information relative to that timestamp, including all the digests grouped on that collection. If it has not been anchored on the blockchain yet, it returns zero. Digests and timestamps can be verified on the same request.
+Verifies the status of a batch of digests or timestamps on the server. If verifying digests, it'll return the chain information relative to that digest, including its merkle path. If verifying timestamps, it'll return the collection information relative to that timestamp, including all the digests grouped on that collection. If it has not been anchored on the blockchain yet, it returns zero. Digests and timestamps can be verified on the same request.
 
 * **URL**
 
@@ -176,14 +176,14 @@ Verifies the status of a batch of digests or timestamps on the server. If verify
 
 	`digests=[{hash},{...}]`
 
-	A list of string hashes to be confirmed by the server.
+	Digests is an array of digests (SHA256 hashes) to send to the server.
 
 	or
 
 	`timestamps=[{timestamp}, {...}]`
 
 
-	A list of int64 timestamps to be confirmed by the server.
+	Timestamps is an array of int64 timestamps to be confirmed by the server.
 
 	**Optional**
 
@@ -263,7 +263,7 @@ Verifies the status of a batch of digests or timestamps on the server. If verify
 
 	`digests`	
 
-	Digests contains all digests grouped and anchored on the collection.
+	Digests contains all digests grouped and anchored on that timestamp collection.
 
 
 * **Example**

--- a/api/v2/api.md
+++ b/api/v2/api.md
@@ -84,6 +84,7 @@ Reply:
 	"result": 1
 }
 ```
+
 #### `Timestamps`
 
 Upload multiple digests to the time server. Behaves the same as /v2/timestamp, except for the hability to send multiple
@@ -156,7 +157,14 @@ Reply:
 	]
 }
 ```
+
 #### `Verify`
+
+Verifies the status of a batch of digests or timestamps on the server. If verifying a digest,
+it'll return the chain information relative to that digest, including its merkle path. If 
+verifying a timestamp, it'll return the collection information relative to that timestamp, 
+including all the digests grouped on that collection. If it has not been anchored on the 
+blockchain yet, it returns zero. Digests and timestamps can be verified on the same request.
 
 * **URL**
 
@@ -172,7 +180,14 @@ Reply:
 
 	`digests=[{hash},{...}]`
 
-	A list of hashes to be confirmed by the server.
+	A list of string hashes to be confirmed by the server.
+
+	or
+
+	`timestamps=[{timestamp}, {...}]`
+
+
+	A list of int64 timestamps to be confirmed by the server.
 
 	**Optional**
 
@@ -185,6 +200,10 @@ Reply:
 	`id`
 
 	id is copied from the original call for the client to use to match calls and responses.
+
+	`digests`
+
+	The batch of digests requested by the client. Each digest will return the following fields:
 
 	`digest`
 
@@ -218,6 +237,39 @@ Reply:
 
 	Merklepath contains additional information for the mined transaction (if available).
 
+	`timestamps`
+
+	The batch of timestamps requested by the client. Each timestamp will return the following fields:
+
+	`servertimestamp`
+
+	The timestamp itself.
+
+	`result`
+
+	Return code, see #Results.
+
+	`collectioninformation`	
+
+	A JSON object with the information about that timestamp collection.
+
+	`chaintimestamp`
+
+	Timestamp from the server.
+
+	`transaction` 
+
+	Transaction hash that includes the digest.
+
+	`merkleroot`
+
+	MerkleRoot of the block containing the transaction (if mined).
+
+	`digests`	
+
+	Digests contains all digests grouped and anchored on the collection.
+
+
 * **Example**
 
 Request:
@@ -228,7 +280,9 @@ Request:
 	"digests":[
         "d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13"
     ],
-	"timestamps":null
+	"timestamps": [
+		1497376800
+	]
 }
 ```
 
@@ -252,7 +306,18 @@ Reply:
 	        }
 	    }
 	}],
-	"timestamps":[]
+	"timestamps":[{
+		"servertimestamp":1497376800,
+		"result":0,
+		"collectioninformation":{
+			"chaintimestamp":0,
+			"transaction":"0000000000000000000000000000000000000000000000000000000000000000",
+			"merkleroot":"0000000000000000000000000000000000000000000000000000000000000000",
+			"digests":[
+				"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13"
+			]
+		}
+	}]
 }
 ```
 

--- a/api/v2/api.md
+++ b/api/v2/api.md
@@ -17,6 +17,7 @@ showing and validating their inclusion in the Decred blockchain.
 
 **Return Codes**
 
+- [`ResultInvalid`](#ResultInvalid)
 - [`ResultOK`](#ResultOK)
 - [`ResultExistsError`](#ResultExistsError)
 - [`ResultDoesntExistsError`](#ResultDoesntExistsError)
@@ -353,28 +354,34 @@ Reply:
 
 ### Results
 
-* `ResultOK`
+* `ResultInvalid`
 
 	`0`
 
-	The Operation completed successfully.
+The requested operation was invalid.
 
-* `ResultExistsError`
+* `ResultOK`
 
 	`1`
 
-The digest was rejected because it exists.  This is only relevant for the
+The operation completed successfully.
+
+* `ResultExistsError`
+
+	`2`
+
+The digest was rejected because it exists. This is only relevant for the
 `Timestamp` call.
 
 * `ResultDoesntExistError`
 
-	`2`
+	`3`
 
-The timestamp or digest could not be found by the server.  This is only 
+The timestamp or digest could not be found by the server. This is only 
 relevant for the `Verify` call.
 
 * `ResultDisabled`
 
-`3`
+	`4`
 
 Querying is disabled.

--- a/api/v2/api.md
+++ b/api/v2/api.md
@@ -104,7 +104,7 @@ digests in a single request.
 
    `digests=[{hash},{...}]`
 
-    Digest is an array of digests (SHA256 hashes) to send to the server.
+    Digests is an array of digests (SHA256 hashes) to send to the server.
 
 	**Optional**
 

--- a/api/v2/api.md
+++ b/api/v2/api.md
@@ -2,7 +2,12 @@
 
 ## V2
 
-This document describes the REST API provided by a `dcrtimed` server. This API allows users to create and upload hashes which are periodically submitted to the Decred blockchain. It gives the option to send a single string digest, as well as multiples in a array of string digests. It also provides the ability to confirm the addition of the hash to a timestamped collection along with showing and validating their inclusion in the Decred blockchain.
+This document describes the REST API provided by a `dcrtimed` server. This API 
+allows users to create and upload hashes which are periodically submitted to 
+the Decred blockchain. It gives the option to send a single string digest, as 
+well as multiples in a array of string digests. It also provides the ability 
+to confirm the addition of the hash to a timestamped collection along with 
+showing and validating their inclusion in the Decred blockchain.
 
 **Methods**
 
@@ -21,7 +26,12 @@ This document describes the REST API provided by a `dcrtimed` server. This API a
 
 #### `Timestamp`
 
-Upload one digest to the time server. The server will then add this digest to a collection and eventually to a transaction that goes in a Decred block. This method returns immediately with the collection the digest has been added to.  You must use the verify call to find out when it has been anchored to a block (which is done in batches at a set time interval that is not related to the api calls).
+Upload one digest to the time server. The server will then add this digest to
+a collection and eventually to a transaction that goes in a Decred block. 
+This method returns immediately with the collection the digest has been added 
+to.You must use the verify call to find out when it has been anchored to a 
+block (which is done in batches at a set time interval that is not related 
+to the api calls).
 
 * **URL**
 
@@ -43,13 +53,15 @@ Upload one digest to the time server. The server will then add this digest to a 
 
    `id=[string]`
 
-	ID is a user provided identifier that may be used in case the client requires a unique identifier.
+	ID is a user provided identifier that may be used in case the client 
+	requires a unique identifier.
 
 * **Results**
 
 	`id`
 
-	id is copied from the original call for the client to use to match calls and responses.
+	id is copied from the original call for the client to use to match calls
+	 and responses.
 
 	`servertimestamp`
 
@@ -61,7 +73,8 @@ Upload one digest to the time server. The server will then add this digest to a 
 
 	`result`
 
-	result is a integer representing the result for the digest. See #Result for details on return codes.
+	result is a integer representing the result for the digest. See #Result
+	 for details on return codes.
 
 * **Example**
 
@@ -70,7 +83,8 @@ Request:
 ```json
 {
     "id":"dcrtime cli",
-    "digest": "d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13"
+    "digest": 
+		"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13"
 }
 ```
 
@@ -80,15 +94,16 @@ Reply:
 {
     "id":"dcrtime cli",
 	"servertimestamp":1497376800,
-	"digest": "d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13",
+	"digest": 
+		"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13",
 	"result": 1
 }
 ```
 
 #### `Timestamps`
 
-Upload multiple digests to the time server. Behaves the same as /v2/timestamp, except for the ability to send multiple
-digests in a single request.
+Upload multiple digests to the time server. Behaves the same as /v2/timestamp, 
+except for the ability to send multiple digests in a single request.
 
 * **URL**
 
@@ -110,13 +125,15 @@ digests in a single request.
 
    `id=[string]`
 
-	ID is a user provided identifier that may be used in case the client requires a unique identifier.
+	ID is a user provided identifier that may be used in case the client 
+	requires a unique identifier.
 
 * **Results**
 
 	`id`
 
-	id is copied from the original call for the client to use to match calls and responses.
+	id is copied from the original call for the client to use to match calls
+	 and responses.
 
 	`servertimestamp`
 
@@ -128,7 +145,8 @@ digests in a single request.
 
 	`results`
 
-	results is a list of integers representing the result for each digest.  See #Results for details on return codes.
+	results is a list of integers representing the result for each digest.  
+	See #Results for details on return codes.
 
 * **Example**
 
@@ -160,7 +178,12 @@ Reply:
 
 #### `Verify`
 
-Verifies the status of a batch of digests or timestamps on the server. If verifying digests, it'll return the chain information relative to that digest, including its merkle path. If verifying timestamps, it'll return the collection information relative to that timestamp, including all the digests grouped on that collection. If it has not been anchored on the blockchain yet, it returns zero. Digests and timestamps can be verified on the same request.
+Verifies the status of a batch of digests or timestamps on the server. If 
+verifying digests, it'll return the chain information relative to that digest, 
+including its merkle path. If verifying timestamps, it'll return the 
+collection information relative to that timestamp, including all the digests 
+grouped on that collection. If it has not been anchored on the blockchain yet, 
+it returns zero. Digests and timestamps can be verified on the same request.
 
 * **URL**
 
@@ -189,17 +212,20 @@ Verifies the status of a batch of digests or timestamps on the server. If verify
 
    `id=[string]`
 
-	ID is a user provided identifier that may be used in case the client requires a unique identifier.
+	ID is a user provided identifier that may be used in case the client 
+	requires a unique identifier.
 
 * **Results**
 
 	`id`
 
-	id is copied from the original call for the client to use to match calls and responses.
+	id is copied from the original call for the client to use to match calls
+	and responses.
 
 	`digests`
 
-	The batch of digests requested by the client. Each digest will return the following fields:
+	The batch of digests requested by the client. Each digest will return the
+	following fields:
 
 	`digest`
 
@@ -231,11 +257,13 @@ Verifies the status of a batch of digests or timestamps on the server. If verify
 
 	`merklepath`
 
-	Merklepath contains additional information for the mined transaction (if available).
+	Merklepath contains additional information for the mined transaction 
+	(if available).
 
 	`timestamps`
 
-	The batch of timestamps requested by the client. Each timestamp will return the following fields:
+	The batch of timestamps requested by the client. Each timestamp will return
+	 the following fields:
 
 	`servertimestamp`
 
@@ -263,7 +291,8 @@ Verifies the status of a batch of digests or timestamps on the server. If verify
 
 	`digests`	
 
-	Digests contains all digests grouped and anchored on that timestamp collection.
+	Digests contains all digests grouped and anchored on that timestamp 
+	collection.
 
 
 * **Example**
@@ -288,13 +317,16 @@ Reply:
 {
     "id":"dcrtime cli",
 	"digests":[{
-	    "digest":"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13",
+	    "digest":
+			"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13",
 	    "servertimestamp":1497376800,
 	    "result":0,
 	    "chaininformation":{
 	        "chaintimestamp":0,
-	        "transaction":"0000000000000000000000000000000000000000000000000000000000000000",
-	        "merkleroot":"0000000000000000000000000000000000000000000000000000000000000000",
+	        "transaction":
+			"0000000000000000000000000000000000000000000000000000000000000000",
+	        "merkleroot":
+			"0000000000000000000000000000000000000000000000000000000000000000",
 	        "merklepath":{
 	            "NumLeaves":0,
 	            "Hashes":null,
@@ -307,10 +339,12 @@ Reply:
 		"result":0,
 		"collectioninformation":{
 			"chaintimestamp":0,
-			"transaction":"0000000000000000000000000000000000000000000000000000000000000000",
-			"merkleroot":"0000000000000000000000000000000000000000000000000000000000000000",
+			"transaction":
+			"0000000000000000000000000000000000000000000000000000000000000000",
+			"merkleroot":
+			"0000000000000000000000000000000000000000000000000000000000000000",
 			"digests":[
-				"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13"
+			"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13"
 			]
 		}
 	}]
@@ -329,13 +363,15 @@ Reply:
 
 	`1`
 
-The digest was rejected because it exists.  This is only relevant for the `Timestamp` call.
+The digest was rejected because it exists.  This is only relevant for the
+`Timestamp` call.
 
 * `ResultDoesntExistError`
 
 	`2`
 
-The timestamp or digest could not be found by the server.  This is only relevant for the `Verify` call.
+The timestamp or digest could not be found by the server.  This is only 
+relevant for the `Verify` call.
 
 * `ResultDisabled`
 

--- a/api/v2/api.md
+++ b/api/v2/api.md
@@ -11,9 +11,11 @@ showing and validating their inclusion in the Decred blockchain.
 
 **Methods**
 
-- [`Timestamp`](#timestamp)
 - [`Timestamps`](#timestamps)
 - [`Verify`](#verify)
+
+- [`Timestamp`](#timestamp)
+
 
 **Return Codes**
 
@@ -25,81 +27,6 @@ showing and validating their inclusion in the Decred blockchain.
 
 ### Methods
 
-#### `Timestamp`
-
-Upload one digest to the time server. The server will then add this digest to
-a collection and eventually to a transaction that goes in a Decred block. 
-This method returns immediately with the collection the digest has been added 
-to.You must use the verify call to find out when it has been anchored to a 
-block (which is done in batches at a set time interval that is not related 
-to the api calls).
-
-* **URL**
-
-  `/v2/timestamp/`
-
-* **HTTP Method:**
-
-  `POST`
-
-*  *Params*
-
-	**Required**
-
-   `digest={hash}`
-
-    Digest is a digest (SHA256 hash) to send to the server.
-
-	**Optional**
-
-   `id=[string]`
-
-	ID is a user provided identifier that may be used in case the client 
-	requires a unique identifier.
-
-* **Results**
-
-	`id`
-
-	id is copied from the original call for the client to use to match calls
-	 and responses.
-
-	`servertimestamp`
-
-	servertimestamp is the collection the digests belong to.
-
-	`digest`
-
-	digest is the digest processed by the server.
-
-	`result`
-
-	result is a integer representing the result for the digest. See #Result
-	 for details on return codes.
-
-* **Example**
-
-Request:
-
-```json
-{
-    "id":"dcrtime cli",
-    "digest": 
-		"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13"
-}
-```
-
-Reply:
-
-```json
-{
-    "id":"dcrtime cli",
-	"servertimestamp":1497376800,
-	"digest": 
-		"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13",
-	"result": 1
-}
-```
 
 #### `Timestamps`
 
@@ -349,6 +276,83 @@ Reply:
 			]
 		}
 	}]
+}
+```
+
+#### `Timestamp`
+
+Upload one digest to the time server from a pure HTML form data on the client 
+side. This route exists to serve JS-disabled clients. The server adds this 
+digest to a collection and eventually to a transaction that goes in a Decred 
+block. This method returns immediately with the collection the digest has been 
+added to. You must use the verify call to find out when it has been anchored to 
+a block (which is done in batches at a set time interval that is not related to 
+the api calls).
+
+* **URL**
+
+  `/v2/timestamp/`
+
+* **HTTP Method:**
+
+  `POST`
+
+*  *Params*
+
+	**Required**
+
+   `digest={hash}`
+
+    Digest is a digest (SHA256 hash) to send to the server.
+
+	**Optional**
+
+   `id=[string]`
+
+	ID is a user provided identifier that may be used in case the client 
+	requires a unique identifier.
+
+* **Results**
+
+	`id`
+
+	id is copied from the original call for the client to use to match calls
+	 and responses.
+
+	`servertimestamp`
+
+	servertimestamp is the collection the digests belong to.
+
+	`digest`
+
+	digest is the digest processed by the server.
+
+	`result`
+
+	result is a integer representing the result for the digest. See #Result
+	 for details on return codes.
+
+* **Example**
+
+Request:
+
+```json
+{
+    "id":"dcrtime cli",
+    "digest": 
+		"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13"
+}
+```
+
+Reply:
+
+```json
+{
+    "id":"dcrtime cli",
+	"servertimestamp":1497376800,
+	"digest": 
+		"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13",
+	"result": 1
 }
 ```
 

--- a/api/v2/api.md
+++ b/api/v2/api.md
@@ -2,7 +2,7 @@
 
 ## V2
 
-This document describes the REST API provided by a `dcrtimed` server. This API allows users to create and upload hashes which are periodically submitted to the Decred blockchain. It gives the option to send a single string digest, as well as multiples in a array of string digests. It also provides the ability to to confirm the addition of the hash to a timestamped collection along with showing and validating their inclusion in the Decred blockchain.
+This document describes the REST API provided by a `dcrtimed` server. This API allows users to create and upload hashes which are periodically submitted to the Decred blockchain. It gives the option to send a single string digest, as well as multiples in a array of string digests. It also provides the ability to confirm the addition of the hash to a timestamped collection along with showing and validating their inclusion in the Decred blockchain.
 
 **Methods**
 
@@ -160,11 +160,7 @@ Reply:
 
 #### `Verify`
 
-Verifies the status of a batch of digests or timestamps on the server. If verifying a digest,
-it'll return the chain information relative to that digest, including its merkle path. If 
-verifying a timestamp, it'll return the collection information relative to that timestamp, 
-including all the digests grouped on that collection. If it has not been anchored on the 
-blockchain yet, it returns zero. Digests and timestamps can be verified on the same request.
+Verifies the status of a batch of digests or timestamps on the server. If verifying a digest, it'll return the chain information relative to that digest, including its merkle path. If verifying a timestamp, it'll return the collection information relative to that timestamp, including all the digests grouped on that collection. If it has not been anchored on the blockchain yet, it returns zero. Digests and timestamps can be verified on the same request.
 
 * **URL**
 

--- a/api/v2/api.md
+++ b/api/v2/api.md
@@ -1,0 +1,283 @@
+# dcrtime API Specification
+
+## V2
+
+This document describes the REST API provided by a `dcrtimed` server. This API allows users to create and upload hashes which are periodically submitted to the Decred blockchain. It gives the option to send a single string digest, as well as multiples in a array of string digests. It also provides the ability to to confirm the addition of the hash to a timestamped collection along with showing and validating their inclusion in the Decred blockchain.
+
+**Methods**
+
+- [`Timestamp`](#timestamp)
+- [`Timestamps`](#timestamps)
+- [`Verify`](#verify)
+
+**Return Codes**
+
+- [`ResultOK`](#ResultOK)
+- [`ResultExistsError`](#ResultExistsError)
+- [`ResultDoesntExistsError`](#ResultDoesntExistsError)
+- [`ResultDisabled`](#ResultDisabled)
+
+### Methods
+
+#### `Timestamp`
+
+Upload one digest to the time server. The server will then add this digest to a collection and eventually to a transaction that goes in a Decred block. This method returns immediately with the collection the digest has been added to.  You must use the verify call to find out when it has been anchored to a block (which is done in batches at a set time interval that is not related to the api calls).
+
+* **URL**
+
+  `/v2/timestamp/`
+
+* **HTTP Method:**
+
+  `POST`
+
+*  *Params*
+
+	**Required**
+
+   `digest={hash}`
+
+    Digest is a digest (SHA256 hash) to send to the server.
+
+	**Optional**
+
+   `id=[string]`
+
+	ID is a user provided identifier that may be used in case the client requires a unique identifier.
+
+* **Results**
+
+	`id`
+
+	id is copied from the original call for the client to use to match calls and responses.
+
+	`servertimestamp`
+
+	servertimestamp is the collection the digests belong to.
+
+	`digest`
+
+	digest is the digest processed by the server.
+
+	`result`
+
+	result is a integer representing the result for the digest. See #Result for details on return codes.
+
+* **Example**
+
+Request:
+
+```json
+{
+    "id":"dcrtime cli",
+    "digest": "d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13"
+}
+```
+
+Reply:
+
+```json
+{
+    "id":"dcrtime cli",
+	"servertimestamp":1497376800,
+	"digest": "d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13",
+	"result": 1
+}
+```
+#### `Timestamps`
+
+Upload multiple digests to the time server. Behaves the same as /v2/timestamp, except for the hability to send multiple
+hashes in a single request.
+
+* **URL**
+
+  `/v2/timestamps/`
+
+* **HTTP Method:**
+
+  `POST`
+
+*  *Params*
+
+	**Required**
+
+   `digests=[{hash},{...}]`
+
+    Digest is an array of digests (SHA256 hashes) to send to the server.
+
+	**Optional**
+
+   `id=[string]`
+
+	ID is a user provided identifier that may be used in case the client requires a unique identifier.
+
+* **Results**
+
+	`id`
+
+	id is copied from the original call for the client to use to match calls and responses.
+
+	`servertimestamp`
+
+	servertimestamp is the collection the digests belong to.
+
+	`digests`
+
+	digests is the list of digests processed by the server.
+
+	`results`
+
+	results is a list of integers representing the result for each digest.  See #Results for details on return codes.
+
+* **Example**
+
+Request:
+
+```json
+{
+    "id":"dcrtime cli",
+    "digests":[
+        "d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13"
+    ]
+}
+```
+
+Reply:
+
+```json
+{
+    "id":"dcrtime cli",
+	"servertimestamp":1497376800,
+	"digests":[
+	    "d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13"
+	],
+	"results":[
+	    1
+	]
+}
+```
+#### `Verify`
+
+* **URL**
+
+  `/v2/verify/`
+
+* **HTTP Method:**
+
+  `POST`
+
+*  *Params*
+
+	**Required**
+
+	`digests=[{hash},{...}]`
+
+	A list of hashes to be confirmed by the server.
+
+	**Optional**
+
+   `id=[string]`
+
+	ID is a user provided identifier that may be used in case the client requires a unique identifier.
+
+* **Results**
+
+	`id`
+
+	id is copied from the original call for the client to use to match calls and responses.
+
+	`digest`
+
+	The digest processed by the server.
+
+	`servertimestamp`
+
+	The collection the digest belongs to (if anchored).
+
+	`result`
+
+	Return code, see #Results.
+
+	`chaininformation`
+
+	A JSON object with the information about the onchain timestamp.
+
+	`chaintimestamp`
+
+	Timestamp from the server.
+
+	`transaction`
+
+	Transaction hash that includes the digest.
+
+	`merkleroot`
+
+	MerkleRoot of the block containing the transaction (if mined).
+
+	`merklepath`
+
+	Merklepath contains additional information for the mined transaction (if available).
+
+* **Example**
+
+Request:
+
+```json
+{
+    "id":"dcrtime cli",
+	"digests":[
+        "d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13"
+    ],
+	"timestamps":null
+}
+```
+
+Reply:
+
+```json
+{
+    "id":"dcrtime cli",
+	"digests":[{
+	    "digest":"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13",
+	    "servertimestamp":1497376800,
+	    "result":0,
+	    "chaininformation":{
+	        "chaintimestamp":0,
+	        "transaction":"0000000000000000000000000000000000000000000000000000000000000000",
+	        "merkleroot":"0000000000000000000000000000000000000000000000000000000000000000",
+	        "merklepath":{
+	            "NumLeaves":0,
+	            "Hashes":null,
+	            "Flags":null
+	        }
+	    }
+	}],
+	"timestamps":[]
+}
+```
+
+### Results
+
+* `ResultOK`
+
+	`0`
+
+	The Operation completed successfully.
+
+* `ResultExistsError`
+
+	`1`
+
+The digest was rejected because it exists.  This is only relevant for the `Timestamp` call.
+
+* `ResultDoesntExistError`
+
+	`2`
+
+The timestamp or digest could not be found by the server.  This is only relevant for the `Verify` call.
+
+* `ResultDisabled`
+
+`3`
+
+Querying is disabled.

--- a/api/v2/go.mod
+++ b/api/v2/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrtime/api/v2
+
+go 1.13

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package v2
+
+const (
+	// StatusRoute behaves the same as /v1/status
+	StatusRoute = "/v2/status/"
+
+	// TimestampRoute defines the API route for submitting
+	// a single string digest.
+	TimestampRoute = "/v2/timestamp/"
+
+	// TimestampsRoute behaves the same as /v1/timestamps
+	TimestampsRoute = "/v2/timestamps/" // Multi digest timestamping
+
+	// VerifyRoute behaves the same as /v2/verify
+	VerifyRoute = "/v2/verify/" // Multi verify digests
+)
+
+// Timestamp is used to ask the timestamp server to store a single digest.
+// ID is user settable and can be used as a unique identifier by the client.
+type Timestamp struct {
+	ID     string `json:"id"`
+	Digest string `json:"digest"`
+}
+
+// TimestampReply is returned by the timestamp server after storing a single
+// digest. ID is copied from the originating Timestamp call and can be
+// used by the client as a unique identifier. ServerTimestamp indicates what
+// collection the Digest belongs to. Result holds the result code for the digest.
+type TimestampReply struct {
+	ID              string `json:"id"`
+	ServerTimestamp int64  `json:"servertimestamp"`
+	Digest          string `json:"digest"`
+	Result          int    `json:"result"`
+}

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -27,24 +27,28 @@ const (
 	// and digest verification.
 	VerifyRoute = "/v2/verify/" // Multi verify digests
 
+	// ResultInvalid indicates the operation on the backend was invalid.
+	ResultInvalid ResultT = 0
+
 	// ResultOK indicates the operation completed successfully.
-	ResultOK ResultT = 0
+	ResultOK ResultT = 1
 
 	// ResultExistsError indicates the digest already exists and was
 	// rejected.
-	ResultExistsError ResultT = 1
+	ResultExistsError ResultT = 2
 
 	// ResultDoesntExistError indiciates the timestamp or digest does not
 	// exist.
-	ResultDoesntExistError ResultT = 2
+	ResultDoesntExistError ResultT = 3
 
 	// ResultDisabled indicates querying is disabled.
-	ResultDisabled ResultT = 3
+	ResultDisabled ResultT = 4
 )
 
 var (
 	// Result is a map of possible http results
 	Result = map[ResultT]string{
+		ResultInvalid:          "Invalid",
 		ResultOK:               "OK",
 		ResultExistsError:      "Exists",
 		ResultDoesntExistError: "Doesn't exist",

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -5,6 +5,7 @@
 package v2
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/decred/dcrtime/merkle"
@@ -13,28 +14,8 @@ import (
 type ResultT int
 
 const (
+	// APIVersion defines the version number for this code.
 	APIVersion = 2
-
-	RoutePrefix = "/v2/"
-
-	// VersionRoute defines a top-level API route for retrieving latest version
-	VersionRoute = "/version/"
-
-	// StatusRoute defines the API route for retrieving
-	// the server status.
-	StatusRoute = RoutePrefix + "status/"
-
-	// TimestampRoute defines the API route for submitting
-	// a single string digest.
-	TimestampRoute = RoutePrefix + "timestamp/" // Single digest timestamping
-
-	// TimestampsRoute defines the API route for submitting
-	// a batch of timestamps or digests.
-	TimestampsRoute = RoutePrefix + "timestamps/" // Multi digest timestamping
-
-	// VerifyRoute defines the API route for both timestamp
-	// and digest verification.
-	VerifyRoute = RoutePrefix + "verify/" // Multi verify digests
 
 	// ResultInvalid indicates the operation on the backend was invalid.
 	ResultInvalid ResultT = 0
@@ -71,7 +52,30 @@ const (
 )
 
 var (
-	// Result is a map of possible http results
+	// RoutePrefix is the route url prefix for this version.
+	RoutePrefix = fmt.Sprintf("/v%v", APIVersion)
+
+	// VersionRoute defines a top-level API route for retrieving latest version
+	VersionRoute = "/version"
+
+	// StatusRoute defines the API route for retrieving
+	// the server status.
+	StatusRoute = RoutePrefix + "/status"
+
+	// TimestampRoute defines the API route for submitting
+	// a single string digest.
+	TimestampRoute = RoutePrefix + "/timestamp" // Single digest timestamping
+
+	// TimestampsRoute defines the API route for submitting
+	// a batch of timestamps or digests.
+	TimestampsRoute = RoutePrefix + "/timestamps" // Multi digest timestamping
+
+	// VerifyRoute defines the API route for both timestamp
+	// and digest verification.
+	VerifyRoute = RoutePrefix + "/verify" // Multi verify digests
+
+	// Result defines legible string messages to a timestamping/query
+	// result code.
 	Result = map[ResultT]string{
 		ResultInvalid:          "Invalid",
 		ResultOK:               "OK",

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -4,20 +4,69 @@
 
 package v2
 
+import (
+	"github.com/decred/dcrtime/merkle"
+	"regexp"
+)
+
 const (
-	// StatusRoute behaves the same as /v1/status
+	// StatusRoute defines the API route for retrieving
+	// the server status.
 	StatusRoute = "/v2/status/"
 
 	// TimestampRoute defines the API route for submitting
 	// a single string digest.
-	TimestampRoute = "/v2/timestamp/"
+	TimestampRoute = "/v2/timestamp/" // Single digest timestamping
 
-	// TimestampsRoute behaves the same as /v1/timestamps
+	// TimestampsRoute defines the API route for submitting
+	// a batch of timestamps or digests.
 	TimestampsRoute = "/v2/timestamps/" // Multi digest timestamping
 
-	// VerifyRoute behaves the same as /v2/verify
+	// VerifyRoute defines the API route for both timestamp
+	// and digest verification.
 	VerifyRoute = "/v2/verify/" // Multi verify digests
+
+	// ResultOK indicates the operation completed successfully.
+	ResultOK = 0
+
+	// ResultExistsError indicates the digest already exists and was
+	// rejected.
+	ResultExistsError = 1
+
+	// ResultDoesntExistError indiciates the timestamp or digest does not
+	// exist.
+	ResultDoesntExistError = 2
+
+	// ResultDisabled indicates querying is disabled.
+	ResultDisabled = 3
 )
+
+var (
+	// Result is a map of the possible timestamp status
+	Result = map[int]string{
+		ResultOK:               "OK",
+		ResultExistsError:      "Exists",
+		ResultDoesntExistError: "Doesn't exist",
+		ResultDisabled:         "Query disallowed",
+	}
+
+	// RegexpSHA256 is the valid text representation of a sha256 digest.
+	RegexpSHA256 = regexp.MustCompile("^[A-Fa-f0-9]{64}$")
+
+	// RegexpTimestamp is the valid text representation of a timestamp.
+	RegexpTimestamp = regexp.MustCompile("^[0-9]{10}$")
+)
+
+// Status is used to ask the server if everything is running properly.
+// ID is user settable and can be used as a unique identifier by the client.
+type Status struct {
+	ID string `json:"id"`
+}
+
+// StatusReply is returned by the server if everything is running properly.
+type StatusReply struct {
+	ID string `json:"id"`
+}
 
 // Timestamp is used to ask the timestamp server to store a single digest.
 // ID is user settable and can be used as a unique identifier by the client.
@@ -35,4 +84,70 @@ type TimestampReply struct {
 	ServerTimestamp int64  `json:"servertimestamp"`
 	Digest          string `json:"digest"`
 	Result          int    `json:"result"`
+}
+
+// Timestamps is used to ask the timestamp server to store a batch of digests.
+// ID is user settable and can be used as a unique identifier by the client.
+type Timestamps struct {
+	ID      string   `json:"id"`
+	Digests []string `json:"digests"`
+}
+
+// TimestampsReply is returned by the timestamp server after storing the batch
+// of digests. ID is copied from the originating Timestamp call and can be
+// used by the client as a unique identifier. The ServerTimestamp indicates
+// what collection the Digests belong to. Results contains individual result
+// codes for each digest.
+type TimestampsReply struct {
+	ID              string   `json:"id"`
+	ServerTimestamp int64    `json:"servertimestamp"`
+	Digests         []string `json:"digests"`
+	Results         []int    `json:"results"`
+}
+
+// Verify is used to ask the server about the status of a batch of digests or
+// timestamps
+type Verify struct {
+	ID         string   `json:"id"`
+	Digests    []string `json:"digests"`
+	Timestamps []int64  `json:"timestamps"`
+}
+
+// VerifyDigest is returned by the server after verifying the status of a
+// digest.
+type VerifyDigest struct {
+	Digest           string           `json:"digest"`
+	ServerTimestamp  int64            `json:"servertimestamp"`
+	Result           int              `json:"result"`
+	ChainInformation ChainInformation `json:"chaininformation"`
+}
+
+// VerifyTimestamp is zero if this digest collection is not anchored in the
+// blockchain; it is however set to the block timestamp it was anchored in.
+type VerifyTimestamp struct {
+	ServerTimestamp       int64                 `json:"servertimestamp"`
+	Result                int                   `json:"result"`
+	CollectionInformation CollectionInformation `json:"collectioninformation"`
+}
+
+// VerifyReply is returned by the server with the status results for the requested
+// digests and timestamps.
+type VerifyReply struct {
+	ID         string            `json:"id"`
+	Digests    []VerifyDigest    `json:"digests"`
+	Timestamps []VerifyTimestamp `json:"timestamps"`
+}
+
+type ChainInformation struct {
+	ChainTimestamp int64         `json:"chaintimestamp"`
+	Transaction    string        `json:"transaction"`
+	MerkleRoot     string        `json:"merkleroot"`
+	MerklePath     merkle.Branch `json:"merklepath"`
+}
+
+type CollectionInformation struct {
+	ChainTimestamp int64    `json:"chaintimestamp"`
+	Transaction    string   `json:"transaction"`
+	MerkleRoot     string   `json:"merkleroot"`
+	Digests        []string `json:"digests"`
 }

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -15,24 +15,26 @@ type ResultT int
 const (
 	APIVersion = 2
 
+	RoutePrefix = "/v2/"
+
 	// VersionRoute defines a top-level API route for retrieving latest version
 	VersionRoute = "/version/"
 
 	// StatusRoute defines the API route for retrieving
 	// the server status.
-	StatusRoute = "/v2/status/"
+	StatusRoute = RoutePrefix + "status/"
 
 	// TimestampRoute defines the API route for submitting
 	// a single string digest.
-	TimestampRoute = "/v2/timestamp/" // Single digest timestamping
+	TimestampRoute = RoutePrefix + "timestamp/" // Single digest timestamping
 
 	// TimestampsRoute defines the API route for submitting
 	// a batch of timestamps or digests.
-	TimestampsRoute = "/v2/timestamps/" // Multi digest timestamping
+	TimestampsRoute = RoutePrefix + "timestamps/" // Multi digest timestamping
 
 	// VerifyRoute defines the API route for both timestamp
 	// and digest verification.
-	VerifyRoute = "/v2/verify/" // Multi verify digests
+	VerifyRoute = RoutePrefix + "verify/" // Multi verify digests
 
 	// ResultInvalid indicates the operation on the backend was invalid.
 	ResultInvalid ResultT = 0
@@ -85,11 +87,6 @@ var (
 	RegexpTimestamp = regexp.MustCompile("^[0-9]{10}$")
 )
 
-// VersionReply returns the version the server is currently running
-type VersionReply struct {
-	Version uint `json:"version"` // dcrtime API version
-}
-
 // Status is used to ask the server if everything is running properly.
 // ID is user settable and can be used as a unique identifier by the client.
 type Status struct {
@@ -99,6 +96,12 @@ type Status struct {
 // StatusReply is returned by the server if everything is running properly.
 type StatusReply struct {
 	ID string `json:"id"`
+}
+
+// VersionReply returns the version the server is currently running.
+type VersionReply struct {
+	Versions      []uint   `json:"versions"` // dcrtime API supported versions.
+	RoutePrefixes []string `json:"routeprefixes"`
 }
 
 // Timestamp is used to ask the timestamp server to store a single digest.

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -6,7 +6,6 @@ package v2
 
 import (
 	"github.com/decred/dcrtime/merkle"
-	"regexp"
 )
 
 const (
@@ -49,12 +48,6 @@ var (
 		ResultDoesntExistError: "Doesn't exist",
 		ResultDisabled:         "Query disallowed",
 	}
-
-	// RegexpSHA256 is the valid text representation of a sha256 digest.
-	RegexpSHA256 = regexp.MustCompile("^[A-Fa-f0-9]{64}$")
-
-	// RegexpTimestamp is the valid text representation of a timestamp.
-	RegexpTimestamp = regexp.MustCompile("^[0-9]{10}$")
 )
 
 // Status is used to ask the server if everything is running properly.
@@ -138,6 +131,8 @@ type VerifyReply struct {
 	Timestamps []VerifyTimestamp `json:"timestamps"`
 }
 
+// ChainInformation is returned by the server on a verify digest request. It contains
+// the merkle path of that digest.
 type ChainInformation struct {
 	ChainTimestamp int64         `json:"chaintimestamp"`
 	Transaction    string        `json:"transaction"`
@@ -145,6 +140,8 @@ type ChainInformation struct {
 	MerklePath     merkle.Branch `json:"merklepath"`
 }
 
+// CollectionInformation is returned by the server on a verify timestamp request.
+// It contains all digests grouped on the collection of the requested block timestamp.
 type CollectionInformation struct {
 	ChainTimestamp int64    `json:"chaintimestamp"`
 	Transaction    string   `json:"transaction"`

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -78,6 +78,10 @@ var (
 	// and digest batch verification.
 	VerifyBatchRoute = RoutePrefix + "/verify/batch" // Multi verify digests
 
+	// WalletBalanceRoute defines the API route for retrieving
+	// the account balance from dcrtimed's wallet instance
+	WalletBalanceRoute = RoutePrefix + "/balance"
+
 	// Result defines legible string messages to a timestamping/query
 	// result code.
 	Result = map[ResultT]string{
@@ -214,4 +218,11 @@ type CollectionInformation struct {
 	Transaction    string   `json:"transaction"`
 	MerkleRoot     string   `json:"merkleroot"`
 	Digests        []string `json:"digests"`
+}
+
+// WalletBalanceReply returns balance information of the decred wallet.
+type WalletBalanceReply struct {
+	Total       int64 `json:"total"`
+	Spendable   int64 `json:"spendable"`
+	Unconfirmed int64 `json:"unconfirmed"`
 }

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -11,6 +11,11 @@ import (
 type ResultT int
 
 const (
+	APIVersion = 2
+
+	// VersionRoute defines a top-level API route for retrieving latest version
+	VersionRoute = "/version/"
+
 	// StatusRoute defines the API route for retrieving
 	// the server status.
 	StatusRoute = "/v2/status/"
@@ -55,6 +60,11 @@ var (
 		ResultDisabled:         "Query disallowed",
 	}
 )
+
+// VersionReply returns the version the server is currently running
+type VersionReply struct {
+	Version uint `json:"version"` // dcrtime API version
+}
 
 // Status is used to ask the server if everything is running properly.
 // ID is user settable and can be used as a unique identifier by the client.

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -5,6 +5,8 @@
 package v2
 
 import (
+	"regexp"
+
 	"github.com/decred/dcrtime/merkle"
 )
 
@@ -48,6 +50,22 @@ const (
 
 	// ResultDisabled indicates querying is disabled.
 	ResultDisabled ResultT = 4
+
+	// DefaultMainnetTimeHost indicates the default mainnet time host
+	// server.
+	DefaultMainnetTimeHost = "time.decred.org"
+
+	// DefaultMainnetTimePort indicates the default mainnet time host
+	// port.
+	DefaultMainnetTimePort = "49152"
+
+	// DefaultTestnetTimeHost indicates the default testnet time host
+	// server.
+	DefaultTestnetTimeHost = "time-testnet.decred.org"
+
+	// DefaultTestnetTimePort indicates the default testnet time host
+	// port.
+	DefaultTestnetTimePort = "59152"
 )
 
 var (
@@ -59,6 +77,12 @@ var (
 		ResultDoesntExistError: "Doesn't exist",
 		ResultDisabled:         "Query disallowed",
 	}
+
+	// RegexpSHA256 is the valid text representation of a sha256 digest.
+	RegexpSHA256 = regexp.MustCompile("^[A-Fa-f0-9]{64}$")
+
+	// RegexpTimestamp is the valid text representation of a timestamp.
+	RegexpTimestamp = regexp.MustCompile("^[0-9]{10}$")
 )
 
 // VersionReply returns the version the server is currently running

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -41,7 +41,7 @@ const (
 )
 
 var (
-	// Result is a map of the possible timestamp status
+	// Result is a map of possible http results
 	Result = map[int]string{
 		ResultOK:               "OK",
 		ResultExistsError:      "Exists",

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -8,6 +8,8 @@ import (
 	"github.com/decred/dcrtime/merkle"
 )
 
+type ResultT int
+
 const (
 	// StatusRoute defines the API route for retrieving
 	// the server status.
@@ -26,23 +28,23 @@ const (
 	VerifyRoute = "/v2/verify/" // Multi verify digests
 
 	// ResultOK indicates the operation completed successfully.
-	ResultOK = 0
+	ResultOK ResultT = 0
 
 	// ResultExistsError indicates the digest already exists and was
 	// rejected.
-	ResultExistsError = 1
+	ResultExistsError ResultT = 1
 
 	// ResultDoesntExistError indiciates the timestamp or digest does not
 	// exist.
-	ResultDoesntExistError = 2
+	ResultDoesntExistError ResultT = 2
 
 	// ResultDisabled indicates querying is disabled.
-	ResultDisabled = 3
+	ResultDisabled ResultT = 3
 )
 
 var (
 	// Result is a map of possible http results
-	Result = map[int]string{
+	Result = map[ResultT]string{
 		ResultOK:               "OK",
 		ResultExistsError:      "Exists",
 		ResultDoesntExistError: "Doesn't exist",
@@ -73,10 +75,10 @@ type Timestamp struct {
 // used by the client as a unique identifier. ServerTimestamp indicates what
 // collection the Digest belongs to. Result holds the result code for the digest.
 type TimestampReply struct {
-	ID              string `json:"id"`
-	ServerTimestamp int64  `json:"servertimestamp"`
-	Digest          string `json:"digest"`
-	Result          int    `json:"result"`
+	ID              string  `json:"id"`
+	ServerTimestamp int64   `json:"servertimestamp"`
+	Digest          string  `json:"digest"`
+	Result          ResultT `json:"result"`
 }
 
 // Timestamps is used to ask the timestamp server to store a batch of digests.
@@ -92,10 +94,10 @@ type Timestamps struct {
 // what collection the Digests belong to. Results contains individual result
 // codes for each digest.
 type TimestampsReply struct {
-	ID              string   `json:"id"`
-	ServerTimestamp int64    `json:"servertimestamp"`
-	Digests         []string `json:"digests"`
-	Results         []int    `json:"results"`
+	ID              string    `json:"id"`
+	ServerTimestamp int64     `json:"servertimestamp"`
+	Digests         []string  `json:"digests"`
+	Results         []ResultT `json:"results"`
 }
 
 // Verify is used to ask the server about the status of a batch of digests or
@@ -111,7 +113,7 @@ type Verify struct {
 type VerifyDigest struct {
 	Digest           string           `json:"digest"`
 	ServerTimestamp  int64            `json:"servertimestamp"`
-	Result           int              `json:"result"`
+	Result           ResultT          `json:"result"`
 	ChainInformation ChainInformation `json:"chaininformation"`
 }
 
@@ -119,7 +121,7 @@ type VerifyDigest struct {
 // blockchain; it is however set to the block timestamp it was anchored in.
 type VerifyTimestamp struct {
 	ServerTimestamp       int64                 `json:"servertimestamp"`
-	Result                int                   `json:"result"`
+	Result                ResultT               `json:"result"`
 	CollectionInformation CollectionInformation `json:"collectioninformation"`
 }
 

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -63,16 +63,20 @@ var (
 	StatusRoute = RoutePrefix + "/status"
 
 	// TimestampRoute defines the API route for submitting
-	// a single string digest.
+	// a single string digest, used by no-js clients.
 	TimestampRoute = RoutePrefix + "/timestamp" // Single digest timestamping
 
-	// TimestampsRoute defines the API route for submitting
-	// a batch of timestamps or digests.
-	TimestampsRoute = RoutePrefix + "/timestamps" // Multi digest timestamping
+	// VerifyRoute defines the API route for verifying
+	// a single digest and timestamp, used by no-js clients.
+	VerifyRoute = RoutePrefix + "/verify" // Single verify digest
 
-	// VerifyRoute defines the API route for both timestamp
-	// and digest verification.
-	VerifyRoute = RoutePrefix + "/verify" // Multi verify digests
+	// TimestampBatchRoute defines the API route for submitting
+	// a batch of timestamps or digests.
+	TimestampBatchRoute = RoutePrefix + "/timestamp/batch" // Multi digest timestamping
+
+	// VerifyBatchRoute defines the API route for both timestamp
+	// and digest batch verification.
+	VerifyBatchRoute = RoutePrefix + "/verify/batch" // Multi verify digests
 
 	// Result defines legible string messages to a timestamping/query
 	// result code.
@@ -111,8 +115,8 @@ type VersionReply struct {
 // Timestamp is used to ask the timestamp server to store a single digest.
 // ID is user settable and can be used as a unique identifier by the client.
 type Timestamp struct {
-	ID     string `json:"id"`
-	Digest string `json:"digest"`
+	ID     string `form:"id"`
+	Digest string `form:"digest"`
 }
 
 // TimestampReply is returned by the timestamp server after storing a single
@@ -126,31 +130,20 @@ type TimestampReply struct {
 	Result          ResultT `json:"result"`
 }
 
-// Timestamps is used to ask the timestamp server to store a batch of digests.
-// ID is user settable and can be used as a unique identifier by the client.
-type Timestamps struct {
-	ID      string   `json:"id"`
-	Digests []string `json:"digests"`
-}
-
-// TimestampsReply is returned by the timestamp server after storing the batch
-// of digests. ID is copied from the originating Timestamp call and can be
-// used by the client as a unique identifier. The ServerTimestamp indicates
-// what collection the Digests belong to. Results contains individual result
-// codes for each digest.
-type TimestampsReply struct {
-	ID              string    `json:"id"`
-	ServerTimestamp int64     `json:"servertimestamp"`
-	Digests         []string  `json:"digests"`
-	Results         []ResultT `json:"results"`
-}
-
-// Verify is used to ask the server about the status of a batch of digests or
-// timestamps
+// Verify is used to ask the server about the status of a single digest and/or
+// timestamp.
 type Verify struct {
-	ID         string   `json:"id"`
-	Digests    []string `json:"digests"`
-	Timestamps []int64  `json:"timestamps"`
+	ID        string `form:"id"`
+	Digest    string `form:"digest"`
+	Timestamp int64  `form:"timestamp"`
+}
+
+// VerifyReply is returned by the server with the status results for the requested
+// digest and/or timestamp.
+type VerifyReply struct {
+	ID        string          `json:"id"`
+	Digest    VerifyDigest    `json:"digest"`
+	Timestamp VerifyTimestamp `json:"timestamp"`
 }
 
 // VerifyDigest is returned by the server after verifying the status of a
@@ -170,9 +163,36 @@ type VerifyTimestamp struct {
 	CollectionInformation CollectionInformation `json:"collectioninformation"`
 }
 
-// VerifyReply is returned by the server with the status results for the requested
+// TimestampBatch is used to ask the timestamp server to store a batch of digests.
+// ID is user settable and can be used as a unique identifier by the client.
+type TimestampBatch struct {
+	ID      string   `json:"id"`
+	Digests []string `json:"digests"`
+}
+
+// TimestampBatchReply is returned by the timestamp server after storing the batch
+// of digests. ID is copied from the originating Timestamp call and can be
+// used by the client as a unique identifier. The ServerTimestamp indicates
+// what collection the Digests belong to. Results contains individual result
+// codes for each digest.
+type TimestampBatchReply struct {
+	ID              string    `json:"id"`
+	ServerTimestamp int64     `json:"servertimestamp"`
+	Digests         []string  `json:"digests"`
+	Results         []ResultT `json:"results"`
+}
+
+// VerifyBatch is used to ask the server about the status of a batch of digests or
+// timestamps
+type VerifyBatch struct {
+	ID         string   `json:"id"`
+	Digests    []string `json:"digests"`
+	Timestamps []int64  `json:"timestamps"`
+}
+
+// VerifyBatchReply is returned by the server with the status results for the requested
 // digests and timestamps.
-type VerifyReply struct {
+type VerifyBatchReply struct {
 	ID         string            `json:"id"`
 	Digests    []VerifyDigest    `json:"digests"`
 	Timestamps []VerifyTimestamp `json:"timestamps"`

--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"strconv"
 
-	v1 "github.com/decred/dcrtime/api/v1"
+	v2 "github.com/decred/dcrtime/api/v2"
 	"github.com/decred/dcrtime/merkle"
 	"github.com/decred/dcrtime/util"
 )
@@ -74,12 +74,12 @@ func isFile(filename string) bool {
 
 // isDigest determines if a string is a valid SHA256 digest.
 func isDigest(digest string) bool {
-	return v1.RegexpSHA256.MatchString(digest)
+	return v2.RegexpSHA256.MatchString(digest)
 }
 
 // isTimestamp determines if a string is a valid UNIX timestamp.
 func isTimestamp(timestamp string) bool {
-	return v1.RegexpTimestamp.MatchString(timestamp)
+	return v2.RegexpTimestamp.MatchString(timestamp)
 }
 
 // getError returns the error that is embedded in a JSON reply.
@@ -139,7 +139,7 @@ func newClient(skipVerify bool) *http.Client {
 }
 
 func download(questions []string) error {
-	ver := v1.Verify{
+	ver := v2.Verify{
 		ID: dcrtimeClientID,
 	}
 
@@ -173,7 +173,7 @@ func download(questions []string) error {
 	}
 
 	c := newClient(false)
-	r, err := c.Post(*host+v1.VerifyRoute, "application/json",
+	r, err := c.Post(*host+v2.VerifyRoute, "application/json",
 		bytes.NewReader(b))
 	if err != nil {
 		return err
@@ -195,14 +195,14 @@ func download(questions []string) error {
 	}
 
 	// Decode response.
-	var vr v1.VerifyReply
+	var vr v2.VerifyReply
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&vr); err != nil {
 		return fmt.Errorf("could node decode VerifyReply: %v", err)
 	}
 
 	for _, v := range vr.Timestamps {
-		result, ok := v1.Result[v.Result]
+		result, ok := v2.Result[v.Result]
 		if !ok {
 			fmt.Printf("%v invalid error code %v\n", v.ServerTimestamp,
 				v.Result)
@@ -233,7 +233,7 @@ func download(questions []string) error {
 
 		// Print the good news.
 		if v.CollectionInformation.ChainTimestamp == 0 &&
-			v.Result == v1.ResultOK {
+			v.Result == v2.ResultOK {
 			result = "Not anchored"
 		}
 		fmt.Printf("%v %v\n", v.ServerTimestamp, result)
@@ -261,7 +261,7 @@ func download(questions []string) error {
 	}
 
 	for _, v := range vr.Digests {
-		result, ok := v1.Result[v.Result]
+		result, ok := v2.Result[v.Result]
 		if !ok {
 			fmt.Printf("%v invalid error code %v\n", v.Digest,
 				v.Result)
@@ -311,7 +311,7 @@ func download(questions []string) error {
 
 func upload(digests []string, exists map[string]string) error {
 	// batch uploads
-	ts := v1.Timestamp{
+	ts := v2.Timestamps{
 		ID:      dcrtimeClientID,
 		Digests: digests,
 	}
@@ -330,7 +330,7 @@ func upload(digests []string, exists map[string]string) error {
 	}
 
 	c := newClient(false)
-	r, err := c.Post(*host+v1.TimestampRoute, "application/json",
+	r, err := c.Post(*host+v2.TimestampsRoute, "application/json",
 		bytes.NewReader(b))
 	if err != nil {
 		return err
@@ -352,7 +352,7 @@ func upload(digests []string, exists map[string]string) error {
 	}
 
 	// Decode response.
-	var tsReply v1.TimestampReply
+	var tsReply v2.TimestampsReply
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&tsReply); err != nil {
 		return fmt.Errorf("Could node decode TimestampReply: %v", err)
@@ -361,7 +361,7 @@ func upload(digests []string, exists map[string]string) error {
 	// Print human readable results.
 	for k, v := range tsReply.Results {
 		filename := exists[tsReply.Digests[k]]
-		if v == v1.ResultOK {
+		if v == v2.ResultOK {
 			fmt.Printf("%v OK     %v\n", tsReply.Digests[k], filename)
 			continue
 		}
@@ -497,15 +497,15 @@ func _main() error {
 
 	if *host == "" {
 		if *testnet {
-			*host = v1.DefaultTestnetTimeHost
+			*host = v2.DefaultTestnetTimeHost
 		} else {
-			*host = v1.DefaultMainnetTimeHost
+			*host = v2.DefaultMainnetTimeHost
 		}
 	}
 
-	port := v1.DefaultMainnetTimePort
+	port := v2.DefaultMainnetTimePort
 	if *testnet {
-		port = v1.DefaultTestnetTimePort
+		port = v2.DefaultTestnetTimePort
 	}
 
 	*host = normalizeAddress(*host, port)

--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -139,7 +139,7 @@ func newClient(skipVerify bool) *http.Client {
 }
 
 func download(questions []string) error {
-	ver := v2.Verify{
+	ver := v2.VerifyBatch{
 		ID: dcrtimeClientID,
 	}
 
@@ -195,7 +195,7 @@ func download(questions []string) error {
 	}
 
 	// Decode response.
-	var vr v2.VerifyReply
+	var vr v2.VerifyBatchReply
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&vr); err != nil {
 		return fmt.Errorf("could node decode VerifyReply: %v", err)
@@ -311,7 +311,7 @@ func download(questions []string) error {
 
 func upload(digests []string, exists map[string]string) error {
 	// batch uploads
-	ts := v2.Timestamps{
+	ts := v2.TimestampBatch{
 		ID:      dcrtimeClientID,
 		Digests: digests,
 	}
@@ -330,7 +330,7 @@ func upload(digests []string, exists map[string]string) error {
 	}
 
 	c := newClient(false)
-	r, err := c.Post(*host+v2.TimestampsRoute, "application/json",
+	r, err := c.Post(*host+v2.TimestampBatchRoute, "application/json",
 		bytes.NewReader(b))
 	if err != nil {
 		return err
@@ -352,7 +352,7 @@ func upload(digests []string, exists map[string]string) error {
 	}
 
 	// Decode response.
-	var tsReply v2.TimestampsReply
+	var tsReply v2.TimestampBatchReply
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&tsReply); err != nil {
 		return fmt.Errorf("Could node decode TimestampReply: %v", err)

--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -44,7 +44,7 @@ var (
 		` for accessing privileged API resources"`)
 	balance = flag.Bool("balance", false, `long:"balance" description:"Display`+
 		` the connected server's wallet balance. An API Token is required"`)
-	apiVersion = flag.Int("api", 2,
+	apiVersion = flag.Int("api", v2.APIVersion,
 		"Inform the API version to be used by the cli (1 or 2)")
 	skipVerify = flag.Bool("skipverify", false, "Skip TLS certificates"+
 		"verification (not recommended)")
@@ -737,17 +737,6 @@ func hasDigestFlag() bool {
 	return digest != nil && *digest != ""
 }
 
-func hasAPIVersionFlag() bool {
-	return apiVersion != nil && *apiVersion != 0
-}
-
-func isValidAPIVersionFlag(v int) bool {
-	if v == v1.APIVersion || v == v2.APIVersion {
-		return true
-	}
-	return false
-}
-
 // Ensures that there are no conflicting flags
 func ensureFlagCompatibility() error {
 	if *fileOnly && hasDigestFlag() {
@@ -811,31 +800,26 @@ func _main() error {
 	var download func([]string) error
 	var showWalletBalance func() error
 
-	// Validate API version flag and set appropriate values
-	// according to selected version. Default is v2.
-	if hasAPIVersionFlag() {
-		if !isValidAPIVersionFlag(*apiVersion) {
-			return fmt.Errorf("%v is not a valid API version,"+
-				"use version 1 or 2", *apiVersion)
-		}
-		switch *apiVersion {
-		case v1.APIVersion:
-			mainnetHost = v1.DefaultMainnetTimeHost
-			testnetHost = v1.DefaultTestnetTimeHost
-			mainnetPort = v1.DefaultMainnetTimePort
-			testnetPort = v1.DefaultTestnetTimePort
-			upload = uploadV1
-			download = downloadV1
-			showWalletBalance = showWalletBalanceV1
-		case v2.APIVersion:
-			mainnetHost = v2.DefaultMainnetTimeHost
-			testnetHost = v2.DefaultTestnetTimeHost
-			mainnetPort = v2.DefaultMainnetTimePort
-			testnetPort = v2.DefaultTestnetTimePort
-			upload = uploadV2
-			download = downloadV2
-			showWalletBalance = showWalletBalanceV2
-		}
+	// Set values according to selected API version. Default is v2.
+	switch *apiVersion {
+	case v1.APIVersion:
+		mainnetHost = v1.DefaultMainnetTimeHost
+		testnetHost = v1.DefaultTestnetTimeHost
+		mainnetPort = v1.DefaultMainnetTimePort
+		testnetPort = v1.DefaultTestnetTimePort
+		upload = uploadV1
+		download = downloadV1
+		showWalletBalance = showWalletBalanceV1
+	case v2.APIVersion:
+		mainnetHost = v2.DefaultMainnetTimeHost
+		testnetHost = v2.DefaultTestnetTimeHost
+		mainnetPort = v2.DefaultMainnetTimePort
+		testnetPort = v2.DefaultTestnetTimePort
+		upload = uploadV2
+		download = downloadV2
+		showWalletBalance = showWalletBalanceV2
+	default:
+		return fmt.Errorf("Invalid API version %v", *apiVersion)
 	}
 
 	if *host == "" {

--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strconv"
 
+	v1 "github.com/decred/dcrtime/api/v1"
 	v2 "github.com/decred/dcrtime/api/v2"
 	"github.com/decred/dcrtime/merkle"
 	"github.com/decred/dcrtime/util"
@@ -42,6 +43,8 @@ var (
 		` for accessing privileged API resources"`)
 	balance = flag.Bool("balance", false, `long:"balance" description:"Display`+
 		` the connected server's wallet balance. An API Token is required"`)
+	apiVersion = flag.Int("api", 0,
+		"Inform the API version to be used by the cli (1 or 2)")
 )
 
 // normalizeAddress returns addr with the passed default port appended if
@@ -138,7 +141,178 @@ func newClient(skipVerify bool) *http.Client {
 	return &http.Client{Transport: tr}
 }
 
-func download(questions []string) error {
+func downloadV1(questions []string) error {
+	ver := v1.Verify{
+		ID: dcrtimeClientID,
+	}
+
+	for _, question := range questions {
+		if ts, ok := convertTimestamp(question); ok {
+			ver.Timestamps = append(ver.Timestamps, ts)
+			continue
+		}
+
+		if isDigest(question) {
+			ver.Digests = append(ver.Digests, question)
+			continue
+		}
+
+		return fmt.Errorf("not a digest or timestamp: %v", question)
+	}
+
+	// Convert Verify to JSON
+	b, err := json.Marshal(ver)
+	if err != nil {
+		return err
+	}
+
+	if *debug {
+		fmt.Println(string(b))
+	}
+
+	// If this is a trial run return.
+	if *trial {
+		return nil
+	}
+
+	c := newClient(false)
+	r, err := c.Post(*host+v1.VerifyRoute, "application/json",
+		bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		e, err := getError(r.Body)
+		if err != nil {
+			return fmt.Errorf("%v", r.Status)
+		}
+		return fmt.Errorf("%v: %v", r.Status, e)
+	}
+
+	if *printJson {
+		io.Copy(os.Stdout, r.Body)
+		fmt.Printf("\n")
+		return nil
+	}
+
+	// Decode response.
+	var vr v1.VerifyReply
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&vr); err != nil {
+		return fmt.Errorf("could node decode VerifyReply: %v", err)
+	}
+
+	for _, v := range vr.Timestamps {
+		result, ok := v1.Result[v.Result]
+		if !ok {
+			fmt.Printf("%v invalid error code %v\n", v.ServerTimestamp,
+				v.Result)
+			continue
+		}
+
+		// Verify results if the collection is anchored.
+		if v.CollectionInformation.ChainTimestamp != 0 {
+			// Calculate merkle root of all digests.
+			digests := make([]*[sha256.Size]byte, 0,
+				len(v.CollectionInformation.Digests))
+			for _, digest := range v.CollectionInformation.Digests {
+				d, ok := convertDigest(digest)
+				if !ok {
+					return fmt.Errorf("Invalid digest "+
+						"server response for "+
+						"timestamp: %v",
+						v.ServerTimestamp)
+				}
+				digests = append(digests, &d)
+			}
+			root := merkle.Root(digests)
+			if hex.EncodeToString(root[:]) !=
+				v.CollectionInformation.MerkleRoot {
+				fmt.Printf("invalid merkle root: %v\n", err)
+			}
+		}
+
+		// Print the good news.
+		if v.CollectionInformation.ChainTimestamp == 0 &&
+			v.Result == v1.ResultOK {
+			result = "Not anchored"
+		}
+		fmt.Printf("%v %v\n", v.ServerTimestamp, result)
+
+		if !*verbose {
+			continue
+		}
+
+		prefix := "Digests"
+		for _, digest := range v.CollectionInformation.Digests {
+			fmt.Printf("  %-15v: %v\n", prefix, digest)
+			prefix = ""
+		}
+
+		// Only print additional info if we are anchored
+		if v.CollectionInformation.ChainTimestamp == 0 {
+			continue
+		}
+		fmt.Printf("  %-15v: %v\n", "Chain Timestamp",
+			v.CollectionInformation.ChainTimestamp)
+		fmt.Printf("  %-15v: %v\n", "Merkle Root",
+			v.CollectionInformation.MerkleRoot)
+		fmt.Printf("  %-15v: %v\n", "TxID",
+			v.CollectionInformation.Transaction)
+	}
+
+	for _, v := range vr.Digests {
+		result, ok := v1.Result[v.Result]
+		if !ok {
+			fmt.Printf("%v invalid error code %v\n", v.Digest,
+				v.Result)
+			continue
+		}
+
+		// Verify merkle path.
+		root, err := merkle.VerifyAuthPath(&v.ChainInformation.MerklePath)
+		if err != nil {
+			if err != merkle.ErrEmpty {
+				fmt.Printf("%v invalid auth path %v\n",
+					v.Digest, err)
+				continue
+			}
+			fmt.Printf("%v Not anchored\n", v.Digest)
+			continue
+		}
+
+		// Verify merkle root.
+		merkleRoot, err := hex.DecodeString(v.ChainInformation.MerkleRoot)
+		if err != nil {
+			fmt.Printf("invalid merkle root: %v\n", err)
+			continue
+		}
+		// This is silly since we check against returned root.
+		if !bytes.Equal(root[:], merkleRoot) {
+			fmt.Printf("%v invalid merkle root\n", v.Digest)
+			continue
+		}
+
+		// Print the good news.
+		fmt.Printf("%v %v\n", v.Digest, result)
+
+		if !*verbose {
+			continue
+		}
+		fmt.Printf("  %-15v: %v\n", "Chain Timestamp",
+			v.ChainInformation.ChainTimestamp)
+		fmt.Printf("  %-15v: %v\n", "Merkle Root",
+			v.ChainInformation.MerkleRoot)
+		fmt.Printf("  %-15v: %v\n", "TxID",
+			v.ChainInformation.Transaction)
+	}
+
+	return nil
+}
+
+func downloadV2(questions []string) error {
 	ver := v2.VerifyBatch{
 		ID: dcrtimeClientID,
 	}
@@ -309,7 +483,74 @@ func download(questions []string) error {
 	return nil
 }
 
-func upload(digests []string, exists map[string]string) error {
+func uploadV1(digests []string, exists map[string]string) error {
+	// batch uploads
+	ts := v1.Timestamp{
+		ID:      dcrtimeClientID,
+		Digests: digests,
+	}
+	b, err := json.Marshal(ts)
+	if err != nil {
+		return err
+	}
+
+	if *debug {
+		fmt.Println(string(b))
+	}
+
+	// If this is a trial run return.
+	if *trial {
+		return nil
+	}
+
+	c := newClient(false)
+	r, err := c.Post(*host+v1.TimestampRoute, "application/json",
+		bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		e, err := getError(r.Body)
+		if err != nil {
+			return fmt.Errorf("%v", r.Status)
+		}
+		return fmt.Errorf("%v: %v", r.Status, e)
+	}
+
+	if *printJson {
+		io.Copy(os.Stdout, r.Body)
+		fmt.Printf("\n")
+		return nil
+	}
+
+	// Decode response.
+	var tsReply v1.TimestampReply
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&tsReply); err != nil {
+		return fmt.Errorf("Could node decode TimestampReply: %v", err)
+	}
+
+	// Print human readable results.
+	for k, v := range tsReply.Results {
+		filename := exists[tsReply.Digests[k]]
+		if v == v1.ResultOK {
+			fmt.Printf("%v OK %v\n", tsReply.Digests[k], filename)
+			continue
+		}
+		fmt.Printf("%v Exists %v\n", tsReply.Digests[k], filename)
+	}
+
+	if *verbose {
+		// Print server timestamp.
+		fmt.Printf("Collection timestamp: %v\n", tsReply.ServerTimestamp)
+	}
+
+	return nil
+}
+
+func uploadV2(digests []string, exists map[string]string) error {
 	// batch uploads
 	ts := v2.TimestampBatch{
 		ID:      dcrtimeClientID,
@@ -362,7 +603,7 @@ func upload(digests []string, exists map[string]string) error {
 	for k, v := range tsReply.Results {
 		filename := exists[tsReply.Digests[k]]
 		if v == v2.ResultOK {
-			fmt.Printf("%v OK     %v\n", tsReply.Digests[k], filename)
+			fmt.Printf("%v OK %v\n", tsReply.Digests[k], filename)
 			continue
 		}
 		fmt.Printf("%v Exists %v\n", tsReply.Digests[k], filename)
@@ -380,8 +621,8 @@ func hasDigestFlag() bool {
 	return digest != nil && *digest != ""
 }
 
-func uploadDigest(digest string) error {
-	return upload([]string{digest}, make(map[string]string))
+func hasAPIVersionFlag() bool {
+	return apiVersion != nil && *apiVersion != 0
 }
 
 // Ensures that there are no conflicting flags
@@ -495,17 +736,42 @@ func _main() error {
 		return flagError
 	}
 
+	var mainnetHost string
+	var testnetHost string
+	var mainnetPort string
+	var testnetPort string
+	var upload func([]string, map[string]string) error
+	var download func([]string) error
+
+	// Check if API version flag is set to v1. If not, default
+	// to v2.
+	if hasAPIVersionFlag() && *apiVersion == v1.APIVersion {
+		mainnetHost = v1.DefaultMainnetTimeHost
+		testnetHost = v1.DefaultTestnetTimeHost
+		mainnetPort = v1.DefaultMainnetTimePort
+		testnetPort = v1.DefaultTestnetTimePort
+		upload = uploadV1
+		download = downloadV1
+	} else {
+		mainnetHost = v2.DefaultMainnetTimeHost
+		testnetHost = v2.DefaultTestnetTimeHost
+		mainnetPort = v2.DefaultMainnetTimePort
+		testnetPort = v2.DefaultTestnetTimePort
+		upload = uploadV2
+		download = downloadV2
+	}
+
 	if *host == "" {
 		if *testnet {
-			*host = v2.DefaultTestnetTimeHost
+			*host = testnetHost
 		} else {
-			*host = v2.DefaultMainnetTimeHost
+			*host = mainnetHost
 		}
 	}
 
-	port := v2.DefaultMainnetTimePort
+	port := mainnetPort
 	if *testnet {
-		port = v2.DefaultTestnetTimePort
+		port = testnetPort
 	}
 
 	*host = normalizeAddress(*host, port)
@@ -520,7 +786,7 @@ func _main() error {
 	// Allow submitting a pre-calculated 256 bit digest from the command line,
 	// rather than needing to hash a payload.
 	if hasDigestFlag() {
-		return uploadDigest(*digest)
+		return upload([]string{*digest}, make(map[string]string))
 	}
 
 	// Print the wallet balance via privileged endpoint.
@@ -536,8 +802,8 @@ func _main() error {
 	// We attempt to open files first; if that doesn't work we treat the
 	// args as digests or timestamps.  Digests and timestamps are sent to
 	// the server for lookup.  Use fileOnly to override this behavior.
-	var uploads []string
-	var downloads []string
+	var uploadArr []string
+	var downloadArr []string
 	exists := make(map[string]string) // [digest]filename
 	for _, a := range flag.Args() {
 		// Try to see if argument is a valid file.
@@ -555,7 +821,7 @@ func _main() error {
 			}
 			exists[d] = a
 
-			uploads = append(uploads, d)
+			uploadArr = append(uploadArr, d)
 			if *verbose {
 				fmt.Printf("%v Upload %v\n", d, a)
 			}
@@ -565,7 +831,7 @@ func _main() error {
 		// Argument was not a file, try to see if it is a digest or
 		// timestamp instead.
 		if isDigest(a) || isTimestamp(a) {
-			downloads = append(downloads, a)
+			downloadArr = append(downloadArr, a)
 			if *verbose {
 				fmt.Printf("%-64v Verify\n", a)
 			}
@@ -580,19 +846,19 @@ func _main() error {
 			a)
 	}
 
-	if len(uploads) == 0 && len(downloads) == 0 && !didRunCommand {
+	if len(uploadArr) == 0 && len(downloadArr) == 0 && !didRunCommand {
 		return fmt.Errorf("nothing to do")
 	}
 
-	if len(uploads) != 0 {
-		err := upload(uploads, exists)
+	if len(uploadArr) != 0 {
+		err := upload(uploadArr, exists)
 		if err != nil {
 			return err
 		}
 	}
 
-	if len(downloads) != 0 {
-		err := download(downloads)
+	if len(downloadArr) != 0 {
+		err := download(downloadArr)
 		if err != nil {
 			return err
 		}

--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -625,6 +625,13 @@ func hasAPIVersionFlag() bool {
 	return apiVersion != nil && *apiVersion != 0
 }
 
+func isValidAPIVersionFlag(v int) bool {
+	if v == v1.APIVersion || v == v2.APIVersion {
+		return true
+	}
+	return false
+}
+
 // Ensures that there are no conflicting flags
 func ensureFlagCompatibility() error {
 	if *fileOnly && hasDigestFlag() {
@@ -743,22 +750,29 @@ func _main() error {
 	var upload func([]string, map[string]string) error
 	var download func([]string) error
 
-	// Check if API version flag is set to v1. If not, default
-	// to v2.
-	if hasAPIVersionFlag() && *apiVersion == v1.APIVersion {
-		mainnetHost = v1.DefaultMainnetTimeHost
-		testnetHost = v1.DefaultTestnetTimeHost
-		mainnetPort = v1.DefaultMainnetTimePort
-		testnetPort = v1.DefaultTestnetTimePort
-		upload = uploadV1
-		download = downloadV1
-	} else {
-		mainnetHost = v2.DefaultMainnetTimeHost
-		testnetHost = v2.DefaultTestnetTimeHost
-		mainnetPort = v2.DefaultMainnetTimePort
-		testnetPort = v2.DefaultTestnetTimePort
-		upload = uploadV2
-		download = downloadV2
+	// Validate API version flag and set appropriate values
+	// according to selected version. Default is v2.
+	if hasAPIVersionFlag() {
+		if !isValidAPIVersionFlag(*apiVersion) {
+			return fmt.Errorf("%v is not a valid API version,"+
+				"use version 1 or 2", *apiVersion)
+		}
+		switch *apiVersion {
+		case v1.APIVersion:
+			mainnetHost = v1.DefaultMainnetTimeHost
+			testnetHost = v1.DefaultTestnetTimeHost
+			mainnetPort = v1.DefaultMainnetTimePort
+			testnetPort = v1.DefaultTestnetTimePort
+			upload = uploadV1
+			download = downloadV1
+		case v2.APIVersion:
+			mainnetHost = v2.DefaultMainnetTimeHost
+			testnetHost = v2.DefaultTestnetTimeHost
+			mainnetPort = v2.DefaultMainnetTimePort
+			testnetPort = v2.DefaultTestnetTimePort
+			upload = uploadV2
+			download = downloadV2
+		}
 	}
 
 	if *host == "" {

--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -175,7 +175,7 @@ func downloadV1(questions []string) error {
 		return nil
 	}
 
-	c := newClient(false)
+	c := newClient(*skipVerify)
 	r, err := c.Post(*host+v1.VerifyRoute, "application/json",
 		bytes.NewReader(b))
 	if err != nil {
@@ -346,7 +346,7 @@ func downloadV2(questions []string) error {
 		return nil
 	}
 
-	c := newClient(false)
+	c := newClient(*skipVerify)
 	r, err := c.Post(*host+v2.VerifyRoute, "application/json",
 		bytes.NewReader(b))
 	if err != nil {
@@ -503,7 +503,7 @@ func uploadV1(digests []string, exists map[string]string) error {
 		return nil
 	}
 
-	c := newClient(false)
+	c := newClient(*skipVerify)
 	r, err := c.Post(*host+v1.TimestampRoute, "application/json",
 		bytes.NewReader(b))
 	if err != nil {
@@ -570,7 +570,7 @@ func uploadV2(digests []string, exists map[string]string) error {
 		return nil
 	}
 
-	c := newClient(false)
+	c := newClient(*skipVerify)
 	r, err := c.Post(*host+v2.TimestampBatchRoute, "application/json",
 		bytes.NewReader(b))
 	if err != nil {

--- a/cmd/dcrtime_checker/dcrtime_checker.go
+++ b/cmd/dcrtime_checker/dcrtime_checker.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	v1 "github.com/decred/dcrtime/api/v1"
 	v2 "github.com/decred/dcrtime/api/v2"
 	"github.com/decred/dcrtime/merkle"
 	"github.com/decred/dcrtime/util"
@@ -20,64 +21,22 @@ var (
 	dcrdataHost = flag.String("h", "", "dcrdata host")
 	testnet     = flag.Bool("testnet", false, "Use testnet port")
 	verbose     = flag.Bool("v", false, "Verbose")
+	apiVersion  = flag.Int("api", 0,
+		"Inform the API version to be used by the cli (1 or 2)")
 )
 
-func _main() error {
-	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "dcrtime_checker [-h {dcrdatahost}|"+
-			"-testnet|-v] -f {file} -p {proof}\n\n")
-		flag.PrintDefaults()
-	}
-	flag.Parse()
-
-	// require -f
-	if *file == "" {
-		return fmt.Errorf("must provide -f")
-	}
-
-	// require -p
-	if *proof == "" {
-		return fmt.Errorf("must provide -p")
-	}
-
-	// Ensure proof looks correct
-	fProof, err := os.Open(*proof)
-	if err != nil {
-		return err
-	}
+func verifyV2(digest string, fProof *os.File) error {
 	var vr v2.VerifyBatchReply
 	decoder := json.NewDecoder(fProof)
 	if err := decoder.Decode(&vr); err != nil {
-		return fmt.Errorf("Could node decode VerifyReply: %v", err)
-	}
-
-	// Handle dcrtime host
-	if *dcrdataHost == "" {
-		if *testnet {
-			*dcrdataHost = "https://testnet.dcrdata.org/api/tx/"
-		} else {
-			*dcrdataHost = "https://explorer.dcrdata.org/api/tx/"
-		}
-	} else {
-		if !strings.HasSuffix(*dcrdataHost, "/") {
-			*dcrdataHost += "/"
-		}
-	}
-	// Get file digest
-	d, err := util.DigestFile(*file)
-	if err != nil {
-		return err
-	}
-
-	if *verbose {
-		fmt.Printf("%v  %v\n", d, *file)
+		return fmt.Errorf("Could node decode VerifyBatchReply: %v", err)
 	}
 
 	// Ensure file digest exists in the proof and that the saved answer was
 	// correct
 	found := -1
 	for k, v := range vr.Digests {
-		if v.Digest != d {
+		if v.Digest != digest {
 			continue
 		}
 
@@ -102,13 +61,13 @@ func _main() error {
 			return fmt.Errorf("%v invalid auth path %v",
 				v.Digest, err)
 		}
-		return fmt.Errorf("%v Not anchored\n", v.Digest)
+		return fmt.Errorf("%v Not anchored", v.Digest)
 	}
 
 	// Verify merkle root.
 	merkleRoot, err := hex.DecodeString(v.ChainInformation.MerkleRoot)
 	if err != nil {
-		return fmt.Errorf("invalid merkle root: %v\n", err)
+		return fmt.Errorf("invalid merkle root: %v", err)
 	}
 	// This is silly since we check against returned root.
 	if !bytes.Equal(root[:], merkleRoot) {
@@ -117,7 +76,7 @@ func _main() error {
 
 	// If we made it here we have a valid proof
 	if *verbose {
-		fmt.Printf("%v  Proof  OK\n", d)
+		fmt.Printf("%v  Proof  OK\n", digest)
 	}
 
 	// Verify against dcrdata
@@ -128,7 +87,144 @@ func _main() error {
 	}
 
 	if *verbose {
-		fmt.Printf("%v  Anchor OK\n", d)
+		fmt.Printf("%v  Anchor OK\n", digest)
+	}
+
+	return nil
+}
+
+func verifyV1(digest string, fProof *os.File) error {
+	var vr v1.VerifyReply
+	decoder := json.NewDecoder(fProof)
+	if err := decoder.Decode(&vr); err != nil {
+		return fmt.Errorf("Could node decode VerifyReply: %v", err)
+	}
+
+	// Ensure file digest exists in the proof and that the saved answer was
+	// correct
+	found := -1
+	for k, v := range vr.Digests {
+		if v.Digest != digest {
+			continue
+		}
+
+		found = k
+		break
+	}
+	if found == -1 {
+		return fmt.Errorf("file digest not found in proof")
+	}
+	v := vr.Digests[found]
+
+	// Verify result of matching digest
+	if _, ok := v1.Result[v.Result]; !ok {
+		return fmt.Errorf("%v invalid error code %v", v.Digest,
+			v.Result)
+	}
+
+	// Verify merkle path.
+	root, err := merkle.VerifyAuthPath(&v.ChainInformation.MerklePath)
+	if err != nil {
+		if err != merkle.ErrEmpty {
+			return fmt.Errorf("%v invalid auth path %v",
+				v.Digest, err)
+		}
+		return fmt.Errorf("%v Not anchored", v.Digest)
+	}
+
+	// Verify merkle root.
+	merkleRoot, err := hex.DecodeString(v.ChainInformation.MerkleRoot)
+	if err != nil {
+		return fmt.Errorf("invalid merkle root: %v", err)
+	}
+	// This is silly since we check against returned root.
+	if !bytes.Equal(root[:], merkleRoot) {
+		return fmt.Errorf("%v invalid merkle root", v.Digest)
+	}
+
+	// If we made it here we have a valid proof
+	if *verbose {
+		fmt.Printf("%v  Proof  OK\n", digest)
+	}
+
+	// Verify against dcrdata
+	err = util.VerifyAnchor(*dcrdataHost,
+		vr.Digests[found].ChainInformation.Transaction, root[:])
+	if err != nil {
+		return err
+	}
+
+	if *verbose {
+		fmt.Printf("%v  Anchor OK\n", digest)
+	}
+
+	return nil
+}
+
+func hasAPIVersionFlag() bool {
+	return apiVersion != nil && *apiVersion != 0
+}
+
+func _main() error {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "dcrtime_checker [-h {dcrdatahost}|"+
+			"-testnet|-v] -f {file} -p {proof}\n\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	var verify func(string, *os.File) error
+
+	// Check if API version flag is set to v1. If not, default
+	// to v2.
+	if hasAPIVersionFlag() && *apiVersion == v1.APIVersion {
+		verify = verifyV1
+	} else {
+		verify = verifyV2
+	}
+
+	// require -f
+	if *file == "" {
+		return fmt.Errorf("must provide -f")
+	}
+
+	// require -p
+	if *proof == "" {
+		return fmt.Errorf("must provide -p")
+	}
+
+	// Handle dcrtime host
+	if *dcrdataHost == "" {
+		if *testnet {
+			*dcrdataHost = "https://testnet.dcrdata.org/api/tx/"
+		} else {
+			*dcrdataHost = "https://explorer.dcrdata.org/api/tx/"
+		}
+	} else {
+		if !strings.HasSuffix(*dcrdataHost, "/") {
+			*dcrdataHost += "/"
+		}
+	}
+
+	// Ensure proof looks correct
+	fProof, err := os.Open(*proof)
+	if err != nil {
+		return err
+	}
+
+	// Get file digest
+	d, err := util.DigestFile(*file)
+	if err != nil {
+		return err
+	}
+
+	if *verbose {
+		fmt.Printf("%v  %v\n", d, *file)
+	}
+
+	err = verify(d, fProof)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/dcrtime_checker/dcrtime_checker.go
+++ b/cmd/dcrtime_checker/dcrtime_checker.go
@@ -21,7 +21,7 @@ var (
 	dcrdataHost = flag.String("h", "", "dcrdata host")
 	testnet     = flag.Bool("testnet", false, "Use testnet port")
 	verbose     = flag.Bool("v", false, "Verbose")
-	apiVersion  = flag.Int("api", 0,
+	apiVersion  = flag.Int("api", v2.APIVersion,
 		"Inform the API version to be used by the cli (1 or 2)")
 )
 
@@ -161,10 +161,6 @@ func verifyV1(digest string, fProof *os.File) error {
 	return nil
 }
 
-func hasAPIVersionFlag() bool {
-	return apiVersion != nil && *apiVersion != 0
-}
-
 func _main() error {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "dcrtime_checker [-h {dcrdatahost}|"+
@@ -175,12 +171,14 @@ func _main() error {
 
 	var verify func(string, *os.File) error
 
-	// Check if API version flag is set to v1. If not, default
-	// to v2.
-	if hasAPIVersionFlag() && *apiVersion == v1.APIVersion {
+	// Set values according to selected api version.
+	switch *apiVersion {
+	case v1.APIVersion:
 		verify = verifyV1
-	} else {
+	case v2.APIVersion:
 		verify = verifyV2
+	default:
+		return fmt.Errorf("Invalid API version %v", *apiVersion)
 	}
 
 	// require -f

--- a/cmd/dcrtime_checker/dcrtime_checker.go
+++ b/cmd/dcrtime_checker/dcrtime_checker.go
@@ -45,7 +45,7 @@ func _main() error {
 	if err != nil {
 		return err
 	}
-	var vr v2.VerifyReply
+	var vr v2.VerifyBatchReply
 	decoder := json.NewDecoder(fProof)
 	if err := decoder.Decode(&vr); err != nil {
 		return fmt.Errorf("Could node decode VerifyReply: %v", err)

--- a/cmd/dcrtime_checker/dcrtime_checker.go
+++ b/cmd/dcrtime_checker/dcrtime_checker.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	v1 "github.com/decred/dcrtime/api/v1"
+	v2 "github.com/decred/dcrtime/api/v2"
 	"github.com/decred/dcrtime/merkle"
 	"github.com/decred/dcrtime/util"
 )
@@ -45,7 +45,7 @@ func _main() error {
 	if err != nil {
 		return err
 	}
-	var vr v1.VerifyReply
+	var vr v2.VerifyReply
 	decoder := json.NewDecoder(fProof)
 	if err := decoder.Decode(&vr); err != nil {
 		return fmt.Errorf("Could node decode VerifyReply: %v", err)
@@ -90,8 +90,8 @@ func _main() error {
 	v := vr.Digests[found]
 
 	// Verify result of matching digest
-	if _, ok := v1.Result[v.Result]; !ok {
-		return fmt.Errorf("%v invalid error code %v", v.Digest,
+	if _, ok := v2.Result[v.Result]; !ok {
+		return fmt.Errorf("%v invalid error code %v\n", v.Digest,
 			v.Result)
 	}
 

--- a/cmd/dcrtime_checker/dcrtime_checker.go
+++ b/cmd/dcrtime_checker/dcrtime_checker.go
@@ -91,7 +91,7 @@ func _main() error {
 
 	// Verify result of matching digest
 	if _, ok := v2.Result[v.Result]; !ok {
-		return fmt.Errorf("%v invalid error code %v\n", v.Digest,
+		return fmt.Errorf("%v invalid error code %v", v.Digest,
 			v.Result)
 	}
 

--- a/dcrtimed/config.go
+++ b/dcrtimed/config.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 
 	"github.com/decred/dcrd/dcrutil/v2"
+	v1 "github.com/decred/dcrtime/api/v1"
+	v2 "github.com/decred/dcrtime/api/v2"
 	flags "github.com/jessevdk/go-flags"
 )
 
@@ -37,7 +39,7 @@ var (
 	defaultHTTPSKeyFile  = filepath.Join(defaultHomeDir, "https.key")
 	defaultHTTPSCertFile = filepath.Join(defaultHomeDir, "https.cert")
 	defaultLogDir        = filepath.Join(defaultHomeDir, defaultLogDirname)
-	defaultAPIVersions   = "1,2"
+	defaultAPIVersions   = fmt.Sprintf("%v,%v", v1.APIVersion, v2.APIVersion)
 )
 
 // runServiceCommand is only set to a real function on Windows.  It is used
@@ -448,7 +450,7 @@ func loadConfig() (*config, []string, error) {
 	var apiVersionsError bool
 	apiVersions, err := parseAPIVersionsConfig(cfg.APIVersions)
 	for _, v := range apiVersions {
-		if v != 1 && v != 2 {
+		if v != v1.APIVersion && v != v2.APIVersion {
 			apiVersionsError = true
 		}
 	}

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -1177,7 +1177,8 @@ func _main() error {
 			headers := handlers.AllowedHeaders([]string{"Content-Type"})
 
 			log.Infof("Listen: %v", listen)
-			listenC <- http.ListenAndServe(listen,
+			listenC <- http.ListenAndServeTLS(listen,
+				loadedCfg.HTTPSCert, loadedCfg.HTTPSKey,
 				handlers.CORS(origins, methods, headers)(d.router))
 		}()
 	}

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -130,6 +130,7 @@ func (d *DcrtimeStore) proxyStatusV1(w http.ResponseWriter, r *http.Request) {
 
 	d.sendToBackend(w, r.Method, v1.StatusRoute, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader(b))
+
 	log.Infof("Status %v", r.RemoteAddr)
 }
 
@@ -214,29 +215,27 @@ func (d *DcrtimeStore) proxyStatusV2(w http.ResponseWriter, r *http.Request) {
 }
 
 func (d *DcrtimeStore) proxyTimestampV2(w http.ResponseWriter, r *http.Request) {
-	b, err := ioutil.ReadAll(r.Body)
+	r.ParseForm()
+	dig := r.Form.Get("digest")
+	route := v2.TimestampRoute + "?digest=" + dig
 	r.Body.Close()
-	if err != nil {
-		util.RespondWithError(w, http.StatusBadRequest,
-			"Unable to read request")
-		return
-	}
 
-	d.sendToBackend(w, r.Method, v2.TimestampRoute, r.Header.Get("Content-Type"),
-		r.RemoteAddr, bytes.NewReader(b))
+	d.sendToBackend(w, "GET", route, r.Header.Get("Content-Type"),
+		r.RemoteAddr, bytes.NewReader([]byte{}))
+
+	log.Infof("Timestamp %v", r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyVerifyV2(w http.ResponseWriter, r *http.Request) {
-	b, err := ioutil.ReadAll(r.Body)
+	r.ParseForm()
+	dig := r.Form.Get("digest")
+	route := v2.VerifyRoute + "?digest=" + dig
 	r.Body.Close()
-	if err != nil {
-		util.RespondWithError(w, http.StatusBadRequest,
-			"Unable to read request")
-		return
-	}
 
-	d.sendToBackend(w, r.Method, v2.VerifyRoute, r.Header.Get("Content-Type"),
-		r.RemoteAddr, bytes.NewReader(b))
+	d.sendToBackend(w, r.Method, route, r.Header.Get("Content-Type"),
+		r.RemoteAddr, bytes.NewReader([]byte{}))
+
+	log.Infof("Verify %v", r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyTimestampBatchV2(w http.ResponseWriter, r *http.Request) {
@@ -263,6 +262,8 @@ func (d *DcrtimeStore) proxyTimestampBatchV2(w http.ResponseWriter, r *http.Requ
 	for _, v := range t.Digests {
 		log.Infof("Timestamp %v: %v", r.RemoteAddr, v)
 	}
+
+	log.Infof("TimestampBatch %v", r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyVerifyBatchV2(w http.ResponseWriter, r *http.Request) {
@@ -285,6 +286,7 @@ func (d *DcrtimeStore) proxyVerifyBatchV2(w http.ResponseWriter, r *http.Request
 
 	d.sendToBackend(w, r.Method, v2.VerifyBatchRoute, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader(b))
+
 	log.Infof("Verify %v: Timestamps %v Digests %v",
 		r.RemoteAddr, len(v.Timestamps), len(v.Digests))
 }

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -131,7 +131,7 @@ func (d *DcrtimeStore) proxyStatusV1(w http.ResponseWriter, r *http.Request) {
 	d.sendToBackend(w, r.Method, v1.StatusRoute, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader(b))
 
-	log.Infof("Status %v", r.RemoteAddr)
+	log.Infof("Status to %v from %v", r.URL.Path, r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyTimestampV1(w http.ResponseWriter, r *http.Request) {
@@ -155,7 +155,7 @@ func (d *DcrtimeStore) proxyTimestampV1(w http.ResponseWriter, r *http.Request) 
 		r.RemoteAddr, bytes.NewReader(b))
 
 	for _, v := range t.Digests {
-		log.Infof("Timestamp %v: %v", r.RemoteAddr, v)
+		log.Infof("Timestamp to %v from %v: %v", r.URL.Path, r.RemoteAddr, v)
 	}
 }
 
@@ -178,8 +178,8 @@ func (d *DcrtimeStore) proxyVerifyV1(w http.ResponseWriter, r *http.Request) {
 
 	d.sendToBackend(w, r.Method, v1.VerifyRoute, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader(b))
-	log.Infof("Verify %v: Timestamps %v Digests %v",
-		r.RemoteAddr, len(v.Timestamps), len(v.Digests))
+	log.Infof("Verify to %v from %v: Timestamps %v Digests %v",
+		r.URL.Path, r.RemoteAddr, len(v.Timestamps), len(v.Digests))
 }
 
 func (d *DcrtimeStore) proxyWalletBalanceV1(w http.ResponseWriter, r *http.Request) {
@@ -188,7 +188,7 @@ func (d *DcrtimeStore) proxyWalletBalanceV1(w http.ResponseWriter, r *http.Reque
 	d.sendToBackend(w, r.Method, route, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader([]byte{}))
 
-	log.Infof("WalletBalance %v", r.RemoteAddr)
+	log.Infof("WalletBalance to %v from %v", r.URL.Path, r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyStatusV2(w http.ResponseWriter, r *http.Request) {
@@ -211,7 +211,7 @@ func (d *DcrtimeStore) proxyStatusV2(w http.ResponseWriter, r *http.Request) {
 
 	d.sendToBackend(w, r.Method, v2.StatusRoute, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader(b))
-	log.Infof("Status %v", r.RemoteAddr)
+	log.Infof("Status to %v from %v", r.URL.Path, r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyTimestampV2(w http.ResponseWriter, r *http.Request) {
@@ -223,7 +223,7 @@ func (d *DcrtimeStore) proxyTimestampV2(w http.ResponseWriter, r *http.Request) 
 	d.sendToBackend(w, "GET", route, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader([]byte{}))
 
-	log.Infof("Timestamp %v", r.RemoteAddr)
+	log.Infof("Timestamp to %v from %v", r.URL.Path, r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyVerifyV2(w http.ResponseWriter, r *http.Request) {
@@ -235,7 +235,7 @@ func (d *DcrtimeStore) proxyVerifyV2(w http.ResponseWriter, r *http.Request) {
 	d.sendToBackend(w, r.Method, route, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader([]byte{}))
 
-	log.Infof("Verify %v", r.RemoteAddr)
+	log.Infof("Verify to %v from %v", r.URL.Path, r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyTimestampBatchV2(w http.ResponseWriter, r *http.Request) {
@@ -263,7 +263,7 @@ func (d *DcrtimeStore) proxyTimestampBatchV2(w http.ResponseWriter, r *http.Requ
 		log.Infof("Timestamp %v: %v", r.RemoteAddr, v)
 	}
 
-	log.Infof("TimestampBatch %v", r.RemoteAddr)
+	log.Infof("TimestampBatch to %v from %v", r.URL.Path, r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyVerifyBatchV2(w http.ResponseWriter, r *http.Request) {
@@ -287,8 +287,8 @@ func (d *DcrtimeStore) proxyVerifyBatchV2(w http.ResponseWriter, r *http.Request
 	d.sendToBackend(w, r.Method, v2.VerifyBatchRoute, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader(b))
 
-	log.Infof("Verify %v: Timestamps %v Digests %v",
-		r.RemoteAddr, len(v.Timestamps), len(v.Digests))
+	log.Infof("VerifyBatch to %v from %v: Timestamps %v Digests %v",
+		r.URL.Path, r.RemoteAddr, len(v.Timestamps), len(v.Digests))
 }
 
 func (d *DcrtimeStore) proxyWalletBalanceV2(w http.ResponseWriter, r *http.Request) {
@@ -297,7 +297,7 @@ func (d *DcrtimeStore) proxyWalletBalanceV2(w http.ResponseWriter, r *http.Reque
 	d.sendToBackend(w, r.Method, route, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader([]byte{}))
 
-	log.Infof("WalletBalance %v", r.RemoteAddr)
+	log.Infof("WalletBalance to %v from %v", r.URL.Path, r.RemoteAddr)
 }
 
 // version returns the supported API versions running on the server.
@@ -329,7 +329,7 @@ func (d *DcrtimeStore) version(w http.ResponseWriter, r *http.Request) {
 	if xff != "" {
 		via = fmt.Sprintf("%v via %v", xff, r.RemoteAddr)
 	}
-	log.Infof("Version %v", via)
+	log.Infof("Version to %v from %v", r.URL.Path, via)
 
 	util.RespondWithJSON(w, http.StatusOK, versionReply)
 }
@@ -356,7 +356,7 @@ func (d *DcrtimeStore) statusV1(w http.ResponseWriter, r *http.Request) {
 	if xff != "" {
 		via = fmt.Sprintf("%v via %v", xff, r.RemoteAddr)
 	}
-	log.Infof("Status %v", via)
+	log.Infof("Status to %v from %v", r.URL.Path, via)
 
 	// Tell client the good news.
 	util.RespondWithJSON(w, http.StatusOK, v1.StatusReply(s))
@@ -431,7 +431,8 @@ func (d *DcrtimeStore) timestampV1(w http.ResponseWriter, r *http.Request) {
 			result = v1.ResultExistsError
 		}
 		results = append(results, result)
-		log.Infof("Timestamp %v: %v %v %x", via, verb, tsS, v.Digest)
+		log.Infof("Timestamp to %v from %v: %v %v %x",
+			r.URL.Path, via, verb, tsS, v.Digest)
 	}
 
 	// We don't set ChainTimestamp until it is included on the chain.
@@ -471,8 +472,8 @@ func (d *DcrtimeStore) verifyV1(w http.ResponseWriter, r *http.Request) {
 	if xff != "" {
 		via = fmt.Sprintf("%v via %v", r.RemoteAddr, xff)
 	}
-	log.Infof("Verify %v: Timestamps %v Digests %v",
-		via, len(v.Timestamps), len(digests))
+	log.Infof("Verify to %v from %v: Timestamps %v Digests %v",
+		r.URL.Path, via, len(v.Timestamps), len(digests))
 
 	// Collect all timestamps.
 	tsr, err := d.backend.GetTimestamps(v.Timestamps)
@@ -602,8 +603,6 @@ func (d *DcrtimeStore) walletBalanceV1(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Infof("WalletBalance %v", r.RemoteAddr)
-
 	balanceResult, err := d.backend.GetBalance()
 	if err != nil {
 		errorCode := time.Now().Unix()
@@ -616,6 +615,8 @@ func (d *DcrtimeStore) walletBalanceV1(w http.ResponseWriter, r *http.Request) {
 				"the following error code: %v", errorCode))
 		return
 	}
+
+	log.Infof("WalletBalance to %v from %v", r.URL.Path, r.RemoteAddr)
 
 	util.RespondWithJSON(w, http.StatusOK, v1.WalletBalanceReply{
 		Total:       balanceResult.Total,
@@ -646,7 +647,7 @@ func (d *DcrtimeStore) statusV2(w http.ResponseWriter, r *http.Request) {
 	if xff != "" {
 		via = fmt.Sprintf("%v via %v", xff, r.RemoteAddr)
 	}
-	log.Infof("Status %v", via)
+	log.Infof("Status to %v from %v", r.URL.Path, via)
 
 	// Tell client the good news.
 	util.RespondWithJSON(w, http.StatusOK, v2.StatusReply(s))
@@ -721,7 +722,8 @@ func (d *DcrtimeStore) timestampBatchV2(w http.ResponseWriter, r *http.Request) 
 			result = v2.ResultExistsError
 		}
 		results = append(results, result)
-		log.Infof("Timestamps %v: %v %v %x", via, verb, tsS, v.Digest)
+		log.Infof("TimestampBatch to %v from %v: %v %v %x",
+			r.URL.Path, via, verb, tsS, v.Digest)
 	}
 
 	// We don't set ChainTimestamp until it is included on the chain.
@@ -761,8 +763,8 @@ func (d *DcrtimeStore) verifyBatchV2(w http.ResponseWriter, r *http.Request) {
 	if xff != "" {
 		via = fmt.Sprintf("%v via %v", r.RemoteAddr, xff)
 	}
-	log.Infof("Verify %v: Timestamps %v Digests %v",
-		via, len(v.Timestamps), len(digests))
+	log.Infof("VerifyBatch to %v from %v: Timestamps %v Digests %v",
+		r.URL.Path, via, len(v.Timestamps), len(digests))
 
 	// Collect all timestamps.
 	tsr, err := d.backend.GetTimestamps(v.Timestamps)
@@ -952,7 +954,8 @@ func (d *DcrtimeStore) timestampV2(w http.ResponseWriter, r *http.Request) {
 		verb = "rejected"
 		result = v2.ResultExistsError
 	}
-	log.Infof("Timestamp %v: %v %v %x", via, verb, tsS, pr.Digest)
+	log.Infof("Timestamp to %v from %v: %v %v %x",
+		r.URL.Path, via, verb, tsS, pr.Digest)
 
 	util.RespondWithJSON(w, http.StatusOK, v2.TimestampReply{
 		ID:              t.ID,
@@ -1004,8 +1007,8 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 	if xff != "" {
 		via = fmt.Sprintf("%v via %v", r.RemoteAddr, xff)
 	}
-	log.Infof("Verify %v: Timestamp %v Digest %v",
-		via, v.Timestamp, digest)
+	log.Infof("Verify to %v from %v: Timestamp %v Digest %v",
+		r.URL.Path, via, v.Timestamp, digest)
 
 	// Collect timestamp.
 	tsr, err := d.backend.GetTimestamps([]int64{v.Timestamp})
@@ -1138,7 +1141,7 @@ func (d *DcrtimeStore) walletBalanceV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Infof("WalletBalance %v", r.RemoteAddr)
+	log.Infof("WalletBalance to %v from %v", r.URL.Path, r.RemoteAddr)
 
 	balanceResult, err := d.backend.GetBalance()
 	if err != nil {

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -1199,11 +1199,9 @@ func _main() error {
 			headers := handlers.AllowedHeaders([]string{"Content-Type"})
 
 			log.Infof("Listen: %v", listen)
-			listenC <- http.ListenAndServe(listen,
+			listenC <- http.ListenAndServeTLS(listen,
+				loadedCfg.HTTPSCert, loadedCfg.HTTPSKey,
 				handlers.CORS(origins, methods, headers)(d.router))
-			// listenC <- http.ListenAndServeTLS(listen,
-			// 	loadedCfg.HTTPSCert, loadedCfg.HTTPSKey,
-			// 	handlers.CORS(origins, methods, headers)(d.router))
 		}()
 	}
 

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -296,10 +296,10 @@ func (d *DcrtimeStore) version(w http.ResponseWriter, r *http.Request) {
 	vs, _ := parseAPIVersionsConfig(d.cfg.APIVersions)
 	for _, v := range vs {
 		switch v {
-		case 1:
+		case v1.APIVersion:
 			versions = append(versions, v1.APIVersion)
 			prefixes = append(prefixes, v1.RoutePrefix)
-		case 2:
+		case v2.APIVersion:
 			versions = append(versions, v2.APIVersion)
 			prefixes = append(prefixes, v2.RoutePrefix)
 		}
@@ -1164,13 +1164,13 @@ func _main() error {
 	// Add handlers according to supported API versions in cfg
 	for _, v := range versions {
 		switch v {
-		case 1:
+		case v1.APIVersion:
 			// API v1 handlers
 			d.router.HandleFunc(v1.StatusRoute, statusV1Route).Methods("POST")
 			d.router.HandleFunc(v1.TimestampRoute, timestampV1Route).Methods("POST")
 			d.router.HandleFunc(v1.VerifyRoute, verifyV1Route).Methods("POST")
 			d.addRoute("GET", v1.WalletBalanceRoute, walletBalanceRoute)
-		case 2:
+		case v2.APIVersion:
 			// API v2 handlers
 			d.router.HandleFunc(v2.StatusRoute, statusV2Route).Methods("POST")
 			d.router.HandleFunc(v2.TimestampRoute, timestampV2Route).Methods("POST")

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -303,7 +303,7 @@ func (d *DcrtimeStore) proxyWalletBalanceV2(w http.ResponseWriter, r *http.Reque
 func (d *DcrtimeStore) version(w http.ResponseWriter, r *http.Request) {
 	var versions []uint
 	var prefixes []string
-	vs, _ := parseAPIVersionsConfig(d.cfg.APIVersions)
+	vs, _ := parseAndValidateAPIVersions(d.cfg.APIVersions)
 	for _, v := range vs {
 		switch v {
 		case v1.APIVersion:
@@ -1373,7 +1373,7 @@ func _main() error {
 	// Top-level route handler
 	d.addRoute("GET", v2.VersionRoute, d.version)
 
-	versions, _ := parseAPIVersionsConfig(loadedCfg.APIVersions)
+	versions, _ := parseAndValidateAPIVersions(loadedCfg.APIVersions)
 
 	// Add handlers according to supported API versions in cfg
 	for _, v := range versions {

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -288,11 +288,26 @@ func (d *DcrtimeStore) proxyVerifyV2(w http.ResponseWriter, r *http.Request) {
 		r.RemoteAddr, len(v.Timestamps), len(v.Digests))
 }
 
-// version returns the current API version running on the server.
+// version returns the supported API versions running on the server.
 // Handles /version
 func (d *DcrtimeStore) version(w http.ResponseWriter, r *http.Request) {
+	var versions []uint
+	var prefixes []string
+	vs, _ := parseAPIVersionsConfig(d.cfg.APIVersions)
+	for _, v := range vs {
+		switch v {
+		case 1:
+			versions = append(versions, v1.APIVersion)
+			prefixes = append(prefixes, v1.RoutePrefix)
+		case 2:
+			versions = append(versions, v2.APIVersion)
+			prefixes = append(prefixes, v2.RoutePrefix)
+		}
+
+	}
 	versionReply := v2.VersionReply{
-		Version: v2.APIVersion,
+		Versions:      versions,
+		RoutePrefixes: prefixes,
 	}
 
 	// Log for audit trail and reuse loop to translate MultiError to JSON

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -213,21 +213,8 @@ func (d *DcrtimeStore) proxyTimestampV2(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	var t v2.Timestamp
-	decoder := json.NewDecoder(bytes.NewReader(b))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&t); err != nil {
-		util.RespondWithError(w, http.StatusBadRequest,
-			"Invalid request payload")
-		return
-	}
-
 	d.sendToBackend(w, r.Method, v2.TimestampRoute, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader(b))
-
-	for _, v := range t.Digest {
-		log.Infof("Timestamp %v: %v", r.RemoteAddr, v)
-	}
 }
 
 func (d *DcrtimeStore) proxyWalletBalance(w http.ResponseWriter, r *http.Request) {
@@ -248,19 +235,8 @@ func (d *DcrtimeStore) proxyVerifyV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var v v2.Verify
-	decoder := json.NewDecoder(bytes.NewReader(b))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&v); err != nil {
-		util.RespondWithError(w, http.StatusBadRequest,
-			"Invalid request payload")
-		return
-	}
-
 	d.sendToBackend(w, r.Method, v2.VerifyRoute, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader(b))
-	log.Infof("Verify %v: Timestamp %v Digest %v",
-		r.RemoteAddr, v.Timestamp, v.Digest)
 }
 
 func (d *DcrtimeStore) proxyTimestampBatchV2(w http.ResponseWriter, r *http.Request) {

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -1173,7 +1173,7 @@ func _main() error {
 		case v2.APIVersion:
 			// API v2 handlers
 			d.router.HandleFunc(v2.StatusRoute, statusV2Route).Methods("POST")
-			d.router.HandleFunc(v2.TimestampRoute, timestampV2Route).Methods("POST")
+			d.router.HandleFunc(v2.TimestampRoute, timestampV2Route).Methods("POST", "GET")
 			d.router.HandleFunc(v2.TimestampsRoute, timestampsV2Route).Methods("POST")
 			d.router.HandleFunc(v2.VerifyRoute, verifyV2Route).Methods("POST")
 		}

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -131,7 +131,7 @@ func (d *DcrtimeStore) proxyStatusV1(w http.ResponseWriter, r *http.Request) {
 	d.sendToBackend(w, r.Method, v1.StatusRoute, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader(b))
 
-	log.Infof("Status to %v from %v", r.URL.Path, r.RemoteAddr)
+	log.Infof("%v Status %v", r.URL.Path, r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyTimestampV1(w http.ResponseWriter, r *http.Request) {
@@ -155,7 +155,7 @@ func (d *DcrtimeStore) proxyTimestampV1(w http.ResponseWriter, r *http.Request) 
 		r.RemoteAddr, bytes.NewReader(b))
 
 	for _, v := range t.Digests {
-		log.Infof("Timestamp to %v from %v: %v", r.URL.Path, r.RemoteAddr, v)
+		log.Infof("%v Timestamp %v: %v", r.URL.Path, r.RemoteAddr, v)
 	}
 }
 
@@ -178,7 +178,7 @@ func (d *DcrtimeStore) proxyVerifyV1(w http.ResponseWriter, r *http.Request) {
 
 	d.sendToBackend(w, r.Method, v1.VerifyRoute, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader(b))
-	log.Infof("Verify to %v from %v: Timestamps %v Digests %v",
+	log.Infof("%v Verify %v: Timestamps %v Digests %v",
 		r.URL.Path, r.RemoteAddr, len(v.Timestamps), len(v.Digests))
 }
 
@@ -188,7 +188,7 @@ func (d *DcrtimeStore) proxyWalletBalanceV1(w http.ResponseWriter, r *http.Reque
 	d.sendToBackend(w, r.Method, route, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader([]byte{}))
 
-	log.Infof("WalletBalance to %v from %v", r.URL.Path, r.RemoteAddr)
+	log.Infof("%v WalletBalance %v", r.URL.Path, r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyStatusV2(w http.ResponseWriter, r *http.Request) {
@@ -211,7 +211,7 @@ func (d *DcrtimeStore) proxyStatusV2(w http.ResponseWriter, r *http.Request) {
 
 	d.sendToBackend(w, r.Method, v2.StatusRoute, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader(b))
-	log.Infof("Status to %v from %v", r.URL.Path, r.RemoteAddr)
+	log.Infof("%v Status %v", r.URL.Path, r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyTimestampV2(w http.ResponseWriter, r *http.Request) {
@@ -223,7 +223,7 @@ func (d *DcrtimeStore) proxyTimestampV2(w http.ResponseWriter, r *http.Request) 
 	d.sendToBackend(w, "GET", route, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader([]byte{}))
 
-	log.Infof("Timestamp to %v from %v", r.URL.Path, r.RemoteAddr)
+	log.Infof("%v Timestamp %v", r.URL.Path, r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyVerifyV2(w http.ResponseWriter, r *http.Request) {
@@ -235,7 +235,7 @@ func (d *DcrtimeStore) proxyVerifyV2(w http.ResponseWriter, r *http.Request) {
 	d.sendToBackend(w, r.Method, route, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader([]byte{}))
 
-	log.Infof("Verify to %v from %v", r.URL.Path, r.RemoteAddr)
+	log.Infof("%v Verify %v", r.URL.Path, r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyTimestampBatchV2(w http.ResponseWriter, r *http.Request) {
@@ -263,7 +263,7 @@ func (d *DcrtimeStore) proxyTimestampBatchV2(w http.ResponseWriter, r *http.Requ
 		log.Infof("Timestamp %v: %v", r.RemoteAddr, v)
 	}
 
-	log.Infof("TimestampBatch to %v from %v", r.URL.Path, r.RemoteAddr)
+	log.Infof("%v TimestampBatch %v", r.URL.Path, r.RemoteAddr)
 }
 
 func (d *DcrtimeStore) proxyVerifyBatchV2(w http.ResponseWriter, r *http.Request) {
@@ -287,7 +287,7 @@ func (d *DcrtimeStore) proxyVerifyBatchV2(w http.ResponseWriter, r *http.Request
 	d.sendToBackend(w, r.Method, v2.VerifyBatchRoute, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader(b))
 
-	log.Infof("VerifyBatch to %v from %v: Timestamps %v Digests %v",
+	log.Infof("%v VerifyBatch %v: Timestamps %v Digests %v",
 		r.URL.Path, r.RemoteAddr, len(v.Timestamps), len(v.Digests))
 }
 
@@ -297,7 +297,7 @@ func (d *DcrtimeStore) proxyWalletBalanceV2(w http.ResponseWriter, r *http.Reque
 	d.sendToBackend(w, r.Method, route, r.Header.Get("Content-Type"),
 		r.RemoteAddr, bytes.NewReader([]byte{}))
 
-	log.Infof("WalletBalance to %v from %v", r.URL.Path, r.RemoteAddr)
+	log.Infof("%v WalletBalance %v", r.URL.Path, r.RemoteAddr)
 }
 
 // version returns the supported API versions running on the server.
@@ -329,7 +329,7 @@ func (d *DcrtimeStore) version(w http.ResponseWriter, r *http.Request) {
 	if xff != "" {
 		via = fmt.Sprintf("%v via %v", xff, r.RemoteAddr)
 	}
-	log.Infof("Version to %v from %v", r.URL.Path, via)
+	log.Infof("%v Version %v", r.URL.Path, via)
 
 	util.RespondWithJSON(w, http.StatusOK, versionReply)
 }
@@ -356,7 +356,7 @@ func (d *DcrtimeStore) statusV1(w http.ResponseWriter, r *http.Request) {
 	if xff != "" {
 		via = fmt.Sprintf("%v via %v", xff, r.RemoteAddr)
 	}
-	log.Infof("Status to %v from %v", r.URL.Path, via)
+	log.Infof("%v Status %v", r.URL.Path, via)
 
 	// Tell client the good news.
 	util.RespondWithJSON(w, http.StatusOK, v1.StatusReply(s))
@@ -431,7 +431,7 @@ func (d *DcrtimeStore) timestampV1(w http.ResponseWriter, r *http.Request) {
 			result = v1.ResultExistsError
 		}
 		results = append(results, result)
-		log.Infof("Timestamp to %v from %v: %v %v %x",
+		log.Infof("%v Timestamp %v: %v %v %x",
 			r.URL.Path, via, verb, tsS, v.Digest)
 	}
 
@@ -472,7 +472,7 @@ func (d *DcrtimeStore) verifyV1(w http.ResponseWriter, r *http.Request) {
 	if xff != "" {
 		via = fmt.Sprintf("%v via %v", r.RemoteAddr, xff)
 	}
-	log.Infof("Verify to %v from %v: Timestamps %v Digests %v",
+	log.Infof("%v Verify %v: Timestamps %v Digests %v",
 		r.URL.Path, via, len(v.Timestamps), len(digests))
 
 	// Collect all timestamps.
@@ -616,7 +616,7 @@ func (d *DcrtimeStore) walletBalanceV1(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Infof("WalletBalance to %v from %v", r.URL.Path, r.RemoteAddr)
+	log.Infof("%v WalletBalance %v", r.URL.Path, r.RemoteAddr)
 
 	util.RespondWithJSON(w, http.StatusOK, v1.WalletBalanceReply{
 		Total:       balanceResult.Total,
@@ -647,7 +647,7 @@ func (d *DcrtimeStore) statusV2(w http.ResponseWriter, r *http.Request) {
 	if xff != "" {
 		via = fmt.Sprintf("%v via %v", xff, r.RemoteAddr)
 	}
-	log.Infof("Status to %v from %v", r.URL.Path, via)
+	log.Infof("%v Status %v", r.URL.Path, via)
 
 	// Tell client the good news.
 	util.RespondWithJSON(w, http.StatusOK, v2.StatusReply(s))
@@ -722,7 +722,7 @@ func (d *DcrtimeStore) timestampBatchV2(w http.ResponseWriter, r *http.Request) 
 			result = v2.ResultExistsError
 		}
 		results = append(results, result)
-		log.Infof("TimestampBatch to %v from %v: %v %v %x",
+		log.Infof("%v TimestampBatch %v: %v %v %x",
 			r.URL.Path, via, verb, tsS, v.Digest)
 	}
 
@@ -763,7 +763,7 @@ func (d *DcrtimeStore) verifyBatchV2(w http.ResponseWriter, r *http.Request) {
 	if xff != "" {
 		via = fmt.Sprintf("%v via %v", r.RemoteAddr, xff)
 	}
-	log.Infof("VerifyBatch to %v from %v: Timestamps %v Digests %v",
+	log.Infof("%v VerifyBatch %v: Timestamps %v Digests %v",
 		r.URL.Path, via, len(v.Timestamps), len(digests))
 
 	// Collect all timestamps.
@@ -954,7 +954,7 @@ func (d *DcrtimeStore) timestampV2(w http.ResponseWriter, r *http.Request) {
 		verb = "rejected"
 		result = v2.ResultExistsError
 	}
-	log.Infof("Timestamp to %v from %v: %v %v %x",
+	log.Infof("%v Timestamp %v: %v %v %x",
 		r.URL.Path, via, verb, tsS, pr.Digest)
 
 	util.RespondWithJSON(w, http.StatusOK, v2.TimestampReply{
@@ -1007,7 +1007,7 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 	if xff != "" {
 		via = fmt.Sprintf("%v via %v", r.RemoteAddr, xff)
 	}
-	log.Infof("Verify to %v from %v: Timestamp %v Digest %v",
+	log.Infof("%v Verify %v: Timestamp %v Digest %v",
 		r.URL.Path, via, v.Timestamp, digest)
 
 	// Collect timestamp.
@@ -1141,7 +1141,7 @@ func (d *DcrtimeStore) walletBalanceV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Infof("WalletBalance to %v from %v", r.URL.Path, r.RemoteAddr)
+	log.Infof("%v WalletBalance %v", r.URL.Path, r.RemoteAddr)
 
 	balanceResult, err := d.backend.GetBalance()
 	if err != nil {

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -642,13 +642,12 @@ func (d *DcrtimeStore) statusV2(w http.ResponseWriter, r *http.Request) {
 func (d *DcrtimeStore) timestampV2(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
-	var t v2.Timestamp
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&t); err != nil {
-		util.RespondWithError(w, http.StatusBadRequest,
-			"Invalid request payload")
-		return
+	r.ParseForm()
+	id := r.Form.Get("id")
+	dig := r.Form.Get("digest")
+	t := v2.Timestamp{
+		ID:     id,
+		Digest: dig,
 	}
 
 	// Validate digest. If it is invalid return failure.
@@ -783,7 +782,7 @@ func (d *DcrtimeStore) timestampsV2(w http.ResponseWriter, r *http.Request) {
 			result = v2.ResultExistsError
 		}
 		results = append(results, result)
-		log.Infof("Timestamp %v: %v %v %x", via, verb, tsS, v.Digest)
+		log.Infof("Timestamps %v: %v %v %x", via, verb, tsS, v.Digest)
 	}
 
 	// We don't set ChainTimestamp until it is included on the chain.

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -673,7 +673,7 @@ func (d *DcrtimeStore) timestampV2(w http.ResponseWriter, r *http.Request) {
 		via = fmt.Sprintf("%v via %v", xff, r.RemoteAddr)
 	}
 	var (
-		result int
+		result v2.ResultT
 		verb   string
 	)
 	pr := me[len(me)-1] // Digest from PutResult
@@ -750,10 +750,10 @@ func (d *DcrtimeStore) timestampsV2(w http.ResponseWriter, r *http.Request) {
 		via = fmt.Sprintf("%v via %v", xff, r.RemoteAddr)
 	}
 	var (
-		result int
+		result v2.ResultT
 		verb   string
 	)
-	results := make([]int, 0, len(me))
+	results := make([]v2.ResultT, 0, len(me))
 	tsS := time.Unix(ts, 0).UTC().Format(fStr)
 	for _, v := range me {
 		if v.ErrorCode == backend.ErrorOK {
@@ -929,7 +929,7 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// ConvertDigests receives an array of string digests and converts it to
+// convertDigests receives an array of string digests and converts it to
 // sha256, format currently being used throughout the code.
 func convertDigests(d []string) ([][sha256.Size]byte, error) {
 	result := make([][sha256.Size]byte, 0, len(d))

--- a/dcrtimed/sample-dcrtimed.conf
+++ b/dcrtimed/sample-dcrtimed.conf
@@ -38,3 +38,6 @@
 ; a separate line with each line starting with "apitoken=".
 ; The backend will not start if at least one value is not specified.
 ; apitoken=
+
+; API Versions is a comma-separated list of versions to enable support on the daemon.
+;apiversions=1,2

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/decred/dcrd/txscript/v2 v2.1.0
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/dcrdata/api/types/v4 v4.0.4
+	github.com/decred/dcrtime/api/v2 v2.0.0
+	github.com/decred/dcrwallet v1.2.2
 	github.com/decred/dcrwallet/rpc/walletrpc v0.3.0
 	github.com/decred/slog v1.0.0
 	github.com/gorilla/handlers v1.4.2
@@ -21,3 +23,5 @@ require (
 	github.com/syndtr/goleveldb v1.0.0
 	google.golang.org/grpc v1.27.1
 )
+
+replace github.com/decred/dcrtime/api/v2 => ./api/v2


### PR DESCRIPTION
This PR includes a initial v2 API for dcrtime. It contains the routes previously present on v1, plus a new route that allow clients to send a single digest string to the server. The need for this route was motivated by the no-js version of dcrtimegui. Also, the api v2 directory is being handled by go modules.

It also doesn't make any changes to v1 relative routes and how the daemon handles them, so it's backward compatible, since third parties can still use v1.