### PR TITLE
Retry connection with dcrwallet

### DIFF
--- a/dcrtimed/backend/filesystem/filesystem.go
+++ b/dcrtimed/backend/filesystem/filesystem.go
@@ -831,7 +831,6 @@ func New(root, cert, host string, enableCollections bool, passphrase []byte) (*F
 	fs.enableCollections = enableCollections
 
 	// Runtime bits
-	dcrtimewallet.UseLogger(log)
 	fs.wallet, err = dcrtimewallet.New(cert, host, passphrase)
 	if err != nil {
 		return nil, err

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -26,6 +26,7 @@ import (
 	v2 "github.com/decred/dcrtime/api/v2"
 	"github.com/decred/dcrtime/dcrtimed/backend"
 	"github.com/decred/dcrtime/dcrtimed/backend/filesystem"
+	"github.com/decred/dcrtime/dcrtimed/dcrtimewallet"
 	"github.com/decred/dcrtime/util"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -1268,6 +1269,9 @@ func _main() error {
 	log.Infof("Mode    : %v", mode)
 	log.Infof("Network : %v", activeNetParams.Params.Name)
 	log.Infof("Home dir: %v", loadedCfg.HomeDir)
+
+	// Sets subsystem loggers
+	dcrtimewallet.UseLogger(walletLog)
 
 	// Create the data directory in case it does not exist.
 	err = os.MkdirAll(loadedCfg.DataDir, 0700)

--- a/dcrtimed/dcrtimewallet/dcrtimewallet.go
+++ b/dcrtimed/dcrtimewallet/dcrtimewallet.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -102,7 +103,7 @@ func (d *DcrtimeWallet) Lookup(tx chainhash.Hash) (*Result, error) {
 	}, nil
 }
 
-// Construct creates aand submits an anchored tx with the provided merkle root.
+// Construct creates and submits an anchored tx with the provided merkle root.
 func (d *DcrtimeWallet) Construct(merkleRoot [sha256.Size]byte) (*chainhash.Hash, error) {
 	// Generate script that contains OP_RETURN followed by the merkle root.
 	script, err := txscript.NewScriptBuilder().AddOp(txscript.OP_RETURN).
@@ -188,6 +189,37 @@ func (d *DcrtimeWallet) Close() {
 	d.conn.Close()
 }
 
+// getWalletGrpcConnection tries to estabilish a wallet connection. If it fails,
+// it keeps retrying to connect until max retry attempts is reached.
+func getWalletGrpcConnection(creds credentials.TransportCredentials, host string) (*grpc.ClientConn, error) {
+	var (
+		maxRetries = 100
+		duration   = time.Duration(5 * time.Second)
+		conn       *grpc.ClientConn
+		err        error
+		done       bool
+	)
+
+	for retries := 0; !done; retries++ {
+		if retries == maxRetries {
+			return nil, fmt.Errorf("Max retries exceeded")
+		}
+		conn, err = grpc.Dial(host, grpc.WithBlock(),
+			grpc.WithTransportCredentials(creds),
+			grpc.WithTimeout(duration))
+
+		if err != nil {
+			log.Warnf("Cannot estabilish a dcrwallet connection: %v", err)
+			log.Warnf("Retrying... attempt: %v", retries)
+			continue
+		}
+
+		done = true
+	}
+
+	return conn, nil
+}
+
 // New returns a DcrtimeWallet context.
 func New(cert, host string, passphrase []byte) (*DcrtimeWallet, error) {
 	d := &DcrtimeWallet{
@@ -203,11 +235,11 @@ func New(cert, host string, passphrase []byte) (*DcrtimeWallet, error) {
 	}
 
 	log.Infof("Wallet: %v", host)
-	d.conn, err = grpc.Dial(host, grpc.WithBlock(),
-		grpc.WithTransportCredentials(creds))
+	d.conn, err = getWalletGrpcConnection(creds, host)
 	if err != nil {
 		return nil, err
 	}
+
 	d.wallet = pb.NewWalletServiceClient(d.conn)
 
 	return d, nil

--- a/dcrtimed/dcrtimewallet/log.go
+++ b/dcrtimed/dcrtimewallet/log.go
@@ -28,9 +28,15 @@ import (
 // requests it.
 var log = slog.Disabled
 
-// UseLogger sets the logger to use for the gRPC server.
-func UseLogger(l slog.Logger) {
+// UseGrpcLogger sets the logger to use for the gRPC server.
+func UseGrpcLogger(l slog.Logger) {
 	grpclog.SetLogger(logger{l})
+	log = l
+}
+
+// UseLogger sets the subsystem logger for this package, without
+// gRPC logging.
+func UseLogger(l slog.Logger) {
 	log = l
 }
 

--- a/dcrtimed/log.go
+++ b/dcrtimed/log.go
@@ -40,14 +40,16 @@ var (
 	// application shutdown.
 	logRotator *rotator.Rotator
 
-	log     = backendLog.Logger("DCRT")
-	fsbeLog = backendLog.Logger("FSBE")
+	log       = backendLog.Logger("DCRT")
+	fsbeLog   = backendLog.Logger("FSBE")
+	walletLog = backendLog.Logger("DCRW")
 )
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.
 var subsystemLoggers = map[string]slog.Logger{
 	"DCRT": log,
 	"FSBE": fsbeLog,
+	"DCRW": walletLog,
 }
 
 // initLogRotator initializes the logging rotater to write logs to logFile and


### PR DESCRIPTION
This diff adds a retry connection loop when dcrtimed is unable to connect to dcrwallet. It also adds a subsystem logger for `dcrtimewallet` so that it's able to log on the console.