### PR TITLE
dcrtimed: Init filesystem log.

### DIFF
--- a/dcrtimed/backend/filesystem/filesystem.go
+++ b/dcrtimed/backend/filesystem/filesystem.go
@@ -499,7 +499,7 @@ func (fs *FileSystem) getTimestamp(timestamp int64) (backend.TimestampResult, er
 
 // getDigest tries to return the timestamp information of the provided digest.
 // It tries the global database and if that fails it tries the current
-// timestamp database (it it exists).  This function must be called with the
+// timestamp database (if it exists).  This function must be called with the
 // READ lock held.
 func (fs *FileSystem) getDigest(ts int64, current *leveldb.DB, digest [sha256.Size]byte) (backend.GetResult, error) {
 	gdme := backend.GetResult{

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -1315,6 +1315,7 @@ func _main() error {
 		}
 	} else {
 		// Setup backend.
+		filesystem.UseLogger(fsbeLog)
 		b, err := filesystem.New(loadedCfg.DataDir,
 			loadedCfg.WalletCert,
 			loadedCfg.WalletHost,


### PR DESCRIPTION
 This diff initializes the backend filesystem log, which had been
previously left out by mistake.

