### PR TITLE
README: add apitoken to example's config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,14 @@ wallethost=localhost
 walletcert=../.dcrwallet/rpc.cert
 walletpassphrase=MySikritPa$$w0ard
 testnet=1
-apitoken=sometoken // used to access privileged http endpoints in the daemon.
+apitoken=sometoken
 
 ```
+
+*Note:* `apitoken` key is used to access privileged http endpoints in the daemon.
+Multiple values may be provided by providing multiple apitoken values, each on
+a separate line with each line starting with "apitoken=".
+The backend will not start if at least one value is not specified.
 
 Start the store.
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ apitoken=sometoken
 
 ```
 
-*Note:* `apitoken` key is used to access privileged http endpoints in the daemon.
+**Note:** `apitoken` key is used to access privileged http endpoints in the daemon.
 Multiple values may be provided by providing multiple apitoken values, each on
 a separate line with each line starting with "apitoken=".
 The backend will not start if at least one value is not specified.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ wallethost=localhost
 walletcert=../.dcrwallet/rpc.cert
 walletpassphrase=MySikritPa$$w0ard
 testnet=1
+apitoken=sometoken // used to access privileged http endpoints in the daemon.
+
 ```
 
 Start the store.


### PR DESCRIPTION
This diff adds `apitoken` param to the README's config, 
as it now required to run `dcrtimed`.

Closes #69 