### PR TITLE
multi: last anchor info call.

### DIFF
--- a/api/v1/v1.go
+++ b/api/v1/v1.go
@@ -68,6 +68,11 @@ var (
 	// the account balance from dcrtimed's wallet instance
 	WalletBalanceRoute = RoutePrefix + "/balance"
 
+	// LastAnchorRoute defines the API route for retrieving
+	// info about last successfull anchor, such as
+	// timestamp, block height & tx id
+	LastAnchorRoute = RoutePrefix + "/last"
+
 	// Result defines legible string messages to a timestamping/query
 	// result code.
 	Result = map[int]string{
@@ -159,4 +164,11 @@ type WalletBalanceReply struct {
 	Total       int64 `json:"total"`
 	Spendable   int64 `json:"spendable"`
 	Unconfirmed int64 `json:"unconfirmed"`
+}
+
+type LastAnchorReply struct {
+	ChainTimestamp int64  `json:"chaintimestamp"`
+	Transaction    string `json:"transaction"`
+	BlockHash      string `json:"blockhash"`
+	BlockHeight    int32  `json:"blockheight"`
 }

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -234,7 +234,12 @@ type WalletBalanceReply struct {
 	Unconfirmed int64 `json:"unconfirmed"`
 }
 
-// LastAnchorReply is returned by server on a last anchor info request
+// LastAnchorReply is returned by server on a last succcessful anchor info
+// request, last successful anchor is the last dir which was anchored on the
+// blockchain (it's tx was broadcasted to the network and recorded on the db).
+// ChainTimestamp is stored on db only after 6 confirmations, if that's the
+// case and tx has more than 6 confirmations then LastAnchorReply will
+// include the tx blockchain timestamp.
 type LastAnchorReply struct {
 	ChainTimestamp int64  `json:"chaintimestamp"`
 	Transaction    string `json:"transaction"`

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -235,11 +235,9 @@ type WalletBalanceReply struct {
 }
 
 // LastAnchorReply is returned by server on a last succcessful anchor info
-// request, last successful anchor is the last dir which was anchored on the
-// blockchain (it's tx was broadcasted to the network and recorded on the db).
-// ChainTimestamp is stored on db only after 6 confirmations, if that's the
-// case and tx has more than 6 confirmations then LastAnchorReply will
-// include the tx blockchain timestamp.
+// request, it includes the id of the latest successfully broadcasted tx,
+// block hash & block height if the transaction was included in a block
+// and the chain timestamp if the tx block has more than 6 confirmations.
 type LastAnchorReply struct {
 	ChainTimestamp int64  `json:"chaintimestamp"`
 	Transaction    string `json:"transaction"`

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -82,6 +82,11 @@ var (
 	// the account balance from dcrtimed's wallet instance
 	WalletBalanceRoute = RoutePrefix + "/balance"
 
+	// LastAnchorRoute defines the API route for retrieving
+	// info about last successfull anchor, such as
+	// timestamp, block height & tx id
+	LastAnchorRoute = RoutePrefix + "/last"
+
 	// Result defines legible string messages to a timestamping/query
 	// result code.
 	Result = map[ResultT]string{
@@ -194,16 +199,16 @@ type VerifyBatch struct {
 	Timestamps []int64  `json:"timestamps"`
 }
 
-// VerifyBatchReply is returned by the server with the status results for the requested
-// digests and timestamps.
+// VerifyBatchReply is returned by the server with the status results for the
+// requested digests and timestamps.
 type VerifyBatchReply struct {
 	ID         string            `json:"id"`
 	Digests    []VerifyDigest    `json:"digests"`
 	Timestamps []VerifyTimestamp `json:"timestamps"`
 }
 
-// ChainInformation is returned by the server on a verify digest request. It contains
-// the merkle path of that digest.
+// ChainInformation is returned by the server on a verify digest request.
+// It contains the merkle path of that digest.
 type ChainInformation struct {
 	ChainTimestamp int64         `json:"chaintimestamp"`
 	Transaction    string        `json:"transaction"`
@@ -211,8 +216,9 @@ type ChainInformation struct {
 	MerklePath     merkle.Branch `json:"merklepath"`
 }
 
-// CollectionInformation is returned by the server on a verify timestamp request.
-// It contains all digests grouped on the collection of the requested block timestamp.
+// CollectionInformation is returned by the server on a verify timestamp
+// request. It contains all digests grouped on the collection of the
+// requested block timestamp.
 type CollectionInformation struct {
 	ChainTimestamp int64    `json:"chaintimestamp"`
 	Transaction    string   `json:"transaction"`
@@ -220,9 +226,17 @@ type CollectionInformation struct {
 	Digests        []string `json:"digests"`
 }
 
-// WalletBalanceReply returns balance information of the decred wallet.
+// WalletBalanceReply is returned by serve on a balance information of the
+// decred wallet.
 type WalletBalanceReply struct {
 	Total       int64 `json:"total"`
 	Spendable   int64 `json:"spendable"`
 	Unconfirmed int64 `json:"unconfirmed"`
+}
+
+// LastAnchorReply retu
+type LastAnchorReply struct {
+	ChainTimestamp int64  `json:"chaintimestamp"`
+	Transaction    string `json:"transaction"`
+	Block          string `json:"string"`
 }

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -238,5 +238,6 @@ type WalletBalanceReply struct {
 type LastAnchorReply struct {
 	ChainTimestamp int64  `json:"chaintimestamp"`
 	Transaction    string `json:"transaction"`
-	Block          string `json:"string"`
+	BlockHash      string `json:"blockhash"`
+	BlockHeight    int32  `json:"blockheight"`
 }

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -226,7 +226,7 @@ type CollectionInformation struct {
 	Digests        []string `json:"digests"`
 }
 
-// WalletBalanceReply is returned by serve on a balance information of the
+// WalletBalanceReply is returned by server on a balance information of the
 // decred wallet.
 type WalletBalanceReply struct {
 	Total       int64 `json:"total"`
@@ -234,7 +234,7 @@ type WalletBalanceReply struct {
 	Unconfirmed int64 `json:"unconfirmed"`
 }
 
-// LastAnchorReply retu
+// LastAnchorReply is returned by server on a last anchor info request
 type LastAnchorReply struct {
 	ChainTimestamp int64  `json:"chaintimestamp"`
 	Transaction    string `json:"transaction"`

--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -944,7 +944,9 @@ func lastAnchorV1() error {
 	c := newClient(*skipVerify)
 	route := *host + v1.LastAnchorRoute
 
-	fmt.Println(route)
+	if *debug {
+		fmt.Println(route)
+	}
 
 	request, err := http.NewRequest("GET", route, nil)
 	if err != nil {
@@ -997,7 +999,9 @@ func lastAnchorV2() error {
 	c := newClient(*skipVerify)
 	route := *host + v2.LastAnchorRoute
 
-	fmt.Println(route)
+	if *debug {
+		fmt.Println(route)
+	}
 
 	request, err := http.NewRequest("GET", route, nil)
 	if err != nil {

--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -33,7 +33,7 @@ const (
 var (
 	testnet   = flag.Bool("testnet", false, "Use testnet port")
 	debug     = flag.Bool("debug", false, "Print JSON that is sent to server")
-	printJson = flag.Bool("json", false, "Print JSON response from server")
+	printJSON = flag.Bool("json", false, "Print JSON response from server")
 	fileOnly  = flag.Bool("file", false, "Treat digests and timestamps "+
 		"as file names")
 	host     = flag.String("h", "", "Timestamping host")
@@ -41,10 +41,12 @@ var (
 	trial    = flag.Bool("t", false, "Trial run, don't contact server")
 	verbose  = flag.Bool("v", false, "Verbose")
 	digest   = flag.String("digest", "", "Submit a raw 256 bit digest to anchor")
-	apiToken = flag.String("apitoken", "", `long:"apitoken" description:"Token`+
-		` for accessing privileged API resources"`)
-	balance = flag.Bool("balance", false, `long:"balance" description:"Display`+
-		` the connected server's wallet balance. An API Token is required"`)
+	apiToken = flag.String("apitoken", "", "Token for accessing privileged API"+
+		" resources")
+	balance = flag.Bool("balance", false, "Display the connected server's"+
+		" wallet balance. An API Token is required")
+	lastAnchor = flag.Bool("lastanchor", false, "Display last anchored"+
+		" timestamp details")
 	apiVersion = flag.Int("api", v2.APIVersion,
 		"Inform the API version to be used by the cli (1 or 2)")
 	skipVerify = flag.Bool("skipverify", false, "Skip TLS certificates"+
@@ -198,7 +200,7 @@ func downloadV1(questions []string) error {
 		return fmt.Errorf("%v: %v", r.Status, e)
 	}
 
-	if *printJson {
+	if *printJSON {
 		io.Copy(os.Stdout, r.Body)
 		fmt.Printf("\n")
 		return nil
@@ -373,7 +375,7 @@ func downloadV2Batch(questions []string) error {
 		return fmt.Errorf("%v: %v", r.Status, e)
 	}
 
-	if *printJson {
+	if *printJSON {
 		io.Copy(os.Stdout, r.Body)
 		fmt.Printf("\n")
 		return nil
@@ -439,7 +441,7 @@ func downloadV2Single(question string) error {
 		return fmt.Errorf("%v: %v", r.Status, e)
 	}
 
-	if *printJson {
+	if *printJSON {
 		io.Copy(os.Stdout, r.Body)
 		fmt.Printf("\n")
 		return nil
@@ -634,7 +636,7 @@ func uploadV1(digests []string, exists map[string]string) error {
 		return fmt.Errorf("%v: %v", r.Status, e)
 	}
 
-	if *printJson {
+	if *printJSON {
 		io.Copy(os.Stdout, r.Body)
 		fmt.Printf("\n")
 		return nil
@@ -704,7 +706,7 @@ func uploadV2Batch(digests []string, exists map[string]string) error {
 		return fmt.Errorf("%v: %v", r.Status, e)
 	}
 
-	if *printJson {
+	if *printJSON {
 		io.Copy(os.Stdout, r.Body)
 		fmt.Printf("\n")
 		return nil
@@ -770,7 +772,7 @@ func uploadV2Single(digest string, exists map[string]string) error {
 		return fmt.Errorf("%v: %v", r.Status, e)
 	}
 
-	if *printJson {
+	if *printJSON {
 		io.Copy(os.Stdout, r.Body)
 		fmt.Printf("\n")
 		return nil
@@ -837,7 +839,7 @@ func showWalletBalanceV1() error {
 
 	defer response.Body.Close()
 
-	if *printJson {
+	if *printJSON {
 		io.Copy(os.Stdout, response.Body)
 		fmt.Printf("\n")
 		return nil
@@ -874,6 +876,56 @@ func showWalletBalanceV1() error {
 	return nil
 }
 
+func lastAnchorV2() error {
+	c := newClient(*skipVerify)
+	route := *host + v2.LastAnchorRoute
+
+	fmt.Println(route)
+
+	request, err := http.NewRequest("GET", route, nil)
+	if err != nil {
+		return err
+	}
+
+	response, err := c.Do(request)
+	if err != nil {
+		return err
+	}
+
+	defer response.Body.Close()
+
+	if *printJSON {
+		io.Copy(os.Stdout, response.Body)
+		fmt.Printf("\n")
+		return nil
+	}
+
+	if response.StatusCode != http.StatusOK {
+		e, err := getError(response.Body)
+		if err != nil {
+			return fmt.Errorf("Retrieve last anchor info failed: %v",
+				response.Status)
+		}
+		return fmt.Errorf("Retrieve last anchor info failed - %v: %v",
+			response.Status, e)
+	}
+
+	// Decode the response from dcrtimed
+	var anchor v2.LastAnchorReply
+	jsonDecoder := json.NewDecoder(response.Body)
+	if err := jsonDecoder.Decode(&anchor); err != nil {
+		return fmt.Errorf("Could not decode LastAnchorReply: %v", err)
+	}
+
+	fmt.Printf(
+		"ChainTimestamp:   %v\n"+
+			"Transaction:      %v\n"+
+			"Block:            %v\n",
+		anchor.ChainTimestamp, anchor.Transaction, anchor.Block)
+
+	return nil
+}
+
 // showWalletBalanceV2 returns the total balance of the primary dcrtimed wallet,
 // in atoms.
 func showWalletBalanceV2() error {
@@ -899,7 +951,7 @@ func showWalletBalanceV2() error {
 
 	defer response.Body.Close()
 
-	if *printJson {
+	if *printJSON {
 		io.Copy(os.Stdout, response.Body)
 		fmt.Printf("\n")
 		return nil
@@ -1002,6 +1054,7 @@ func _main() error {
 	var upload func([]string, map[string]string) error
 	var download func([]string) error
 	var showWalletBalance func() error
+	var lastAnchorInfo func() error
 
 	// Set values according to selected API version. Default is v2.
 	switch *apiVersion {
@@ -1021,6 +1074,7 @@ func _main() error {
 		upload = uploadV2
 		download = downloadV2
 		showWalletBalance = showWalletBalanceV2
+		lastAnchorInfo = lastAnchorV2
 	default:
 		return fmt.Errorf("Invalid API version %v", *apiVersion)
 	}
@@ -1059,6 +1113,16 @@ func _main() error {
 	// Print the wallet balance via privileged endpoint.
 	if *balance {
 		err := showWalletBalance()
+		if err != nil {
+			return err
+		}
+
+		didRunCommand = true
+	}
+
+	// Print last anchor timestamp info
+	if *lastAnchor {
+		err := lastAnchorInfo()
 		if err != nil {
 			return err
 		}

--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -920,8 +920,9 @@ func lastAnchorV2() error {
 	fmt.Printf(
 		"ChainTimestamp:   %v\n"+
 			"Transaction:      %v\n"+
-			"Block:            %v\n",
-		anchor.ChainTimestamp, anchor.Transaction, anchor.Block)
+			"Blockhash:        %v\n"+
+			"Blockheight:      %v\n",
+		anchor.ChainTimestamp, anchor.Transaction, anchor.BlockHash, anchor.BlockHeight)
 
 	return nil
 }

--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -876,57 +876,6 @@ func showWalletBalanceV1() error {
 	return nil
 }
 
-func lastAnchorV2() error {
-	c := newClient(*skipVerify)
-	route := *host + v2.LastAnchorRoute
-
-	fmt.Println(route)
-
-	request, err := http.NewRequest("GET", route, nil)
-	if err != nil {
-		return err
-	}
-
-	response, err := c.Do(request)
-	if err != nil {
-		return err
-	}
-
-	defer response.Body.Close()
-
-	if *printJSON {
-		io.Copy(os.Stdout, response.Body)
-		fmt.Printf("\n")
-		return nil
-	}
-
-	if response.StatusCode != http.StatusOK {
-		e, err := getError(response.Body)
-		if err != nil {
-			return fmt.Errorf("Retrieve last anchor info failed: %v",
-				response.Status)
-		}
-		return fmt.Errorf("Retrieve last anchor info failed - %v: %v",
-			response.Status, e)
-	}
-
-	// Decode the response from dcrtimed
-	var anchor v2.LastAnchorReply
-	jsonDecoder := json.NewDecoder(response.Body)
-	if err := jsonDecoder.Decode(&anchor); err != nil {
-		return fmt.Errorf("Could not decode LastAnchorReply: %v", err)
-	}
-
-	fmt.Printf(
-		"ChainTimestamp:   %v\n"+
-			"Transaction:      %v\n"+
-			"Blockhash:        %v\n"+
-			"Blockheight:      %v\n",
-		anchor.ChainTimestamp, anchor.Transaction, anchor.BlockHash, anchor.BlockHeight)
-
-	return nil
-}
-
 // showWalletBalanceV2 returns the total balance of the primary dcrtimed wallet,
 // in atoms.
 func showWalletBalanceV2() error {
@@ -985,6 +934,112 @@ func showWalletBalanceV2() error {
 	} else {
 		fmt.Printf("Spendable wallet balance (atoms): %v\n", balance.Spendable)
 	}
+
+	return nil
+}
+
+// lastAnchorV1 returns the last anchor information
+// such as: tx, chain timestamp, block height & block hash
+func lastAnchorV1() error {
+	c := newClient(*skipVerify)
+	route := *host + v1.LastAnchorRoute
+
+	fmt.Println(route)
+
+	request, err := http.NewRequest("GET", route, nil)
+	if err != nil {
+		return err
+	}
+
+	response, err := c.Do(request)
+	if err != nil {
+		return err
+	}
+
+	defer response.Body.Close()
+
+	if *printJSON {
+		io.Copy(os.Stdout, response.Body)
+		fmt.Printf("\n")
+		return nil
+	}
+
+	if response.StatusCode != http.StatusOK {
+		e, err := getError(response.Body)
+		if err != nil {
+			return fmt.Errorf("Retrieve last anchor info failed: %v",
+				response.Status)
+		}
+		return fmt.Errorf("Retrieve last anchor info failed - %v: %v",
+			response.Status, e)
+	}
+
+	// Decode the response from dcrtimed
+	var anchor v1.LastAnchorReply
+	jsonDecoder := json.NewDecoder(response.Body)
+	if err := jsonDecoder.Decode(&anchor); err != nil {
+		return fmt.Errorf("Could not decode LastAnchorReply: %v", err)
+	}
+
+	fmt.Printf(
+		"ChainTimestamp:   %v\n"+
+			"Transaction:      %v\n"+
+			"Blockhash:        %v\n"+
+			"Blockheight:      %v\n",
+		anchor.ChainTimestamp, anchor.Transaction, anchor.BlockHash, anchor.BlockHeight)
+
+	return nil
+}
+
+// lastAnchorV2 returns the last anchor information
+// such as: tx, chain timestamp, block height & block hash
+func lastAnchorV2() error {
+	c := newClient(*skipVerify)
+	route := *host + v2.LastAnchorRoute
+
+	fmt.Println(route)
+
+	request, err := http.NewRequest("GET", route, nil)
+	if err != nil {
+		return err
+	}
+
+	response, err := c.Do(request)
+	if err != nil {
+		return err
+	}
+
+	defer response.Body.Close()
+
+	if *printJSON {
+		io.Copy(os.Stdout, response.Body)
+		fmt.Printf("\n")
+		return nil
+	}
+
+	if response.StatusCode != http.StatusOK {
+		e, err := getError(response.Body)
+		if err != nil {
+			return fmt.Errorf("Retrieve last anchor info failed: %v",
+				response.Status)
+		}
+		return fmt.Errorf("Retrieve last anchor info failed - %v: %v",
+			response.Status, e)
+	}
+
+	// Decode the response from dcrtimed
+	var anchor v2.LastAnchorReply
+	jsonDecoder := json.NewDecoder(response.Body)
+	if err := jsonDecoder.Decode(&anchor); err != nil {
+		return fmt.Errorf("Could not decode LastAnchorReply: %v", err)
+	}
+
+	fmt.Printf(
+		"ChainTimestamp:   %v\n"+
+			"Transaction:      %v\n"+
+			"Blockhash:        %v\n"+
+			"Blockheight:      %v\n",
+		anchor.ChainTimestamp, anchor.Transaction, anchor.BlockHash, anchor.BlockHeight)
 
 	return nil
 }
@@ -1067,6 +1122,7 @@ func _main() error {
 		upload = uploadV1
 		download = downloadV1
 		showWalletBalance = showWalletBalanceV1
+		lastAnchorInfo = lastAnchorV1
 	case v2.APIVersion:
 		mainnetHost = v2.DefaultMainnetTimeHost
 		testnetHost = v2.DefaultTestnetTimeHost

--- a/dcrtimed/backend/backend.go
+++ b/dcrtimed/backend/backend.go
@@ -126,9 +126,10 @@ type GetBalanceResult struct {
 // LastAnchorResult contains last successful anchor
 // info
 type LastAnchorResult struct {
-	ChainTimestamp int64          `json:"timestamp"` // Timestamp anchored
-	Tx             chainhash.Hash `json:"tx"`        // Tx last succcessfull anchor
-	Block          string         `json:"block"`     // Anchored tx block
+	ChainTimestamp int64          `json:"timestamp"`   // Timestamp anchored
+	Tx             chainhash.Hash `json:"tx"`          // Tx last succcessfull anchor
+	BlockHash      string         `json:"blockhash"`   // Anchored tx block hash
+	BlockHeight    int32          `json:"blockheight"` // Anchored tx block height
 }
 
 // Backend interface

--- a/dcrtimed/backend/backend.go
+++ b/dcrtimed/backend/backend.go
@@ -15,13 +15,13 @@ import (
 
 const (
 	// ErrorOK retuned when everything's cool
-	ErrorOK = 0
+	ErrorOK = 1
 	// ErrorExists returned when digest exists
-	ErrorExists = 1
+	ErrorExists = 2
 	// ErrorNotFound returned as generic not found error
-	ErrorNotFound = 2
+	ErrorNotFound = 3
 	// ErrorNotAllowed returned as generic not allowed error
-	ErrorNotAllowed = 3
+	ErrorNotAllowed = 4
 )
 
 var (

--- a/dcrtimed/backend/backend.go
+++ b/dcrtimed/backend/backend.go
@@ -14,6 +14,8 @@ import (
 )
 
 const (
+	// ErrorInvalid is the default returned error code
+	ErrorInvalid = 0
 	// ErrorOK retuned when everything's cool
 	ErrorOK = 1
 	// ErrorExists returned when digest exists

--- a/dcrtimed/backend/backend.go
+++ b/dcrtimed/backend/backend.go
@@ -14,15 +14,20 @@ import (
 )
 
 const (
-	ErrorOK         = 0 // Everything's cool
-	ErrorExists     = 1 // Digest exists
-	ErrorNotFound   = 2 // Generic not found error
-	ErrorNotAllowed = 3 // Generic not allowed error
+	// ErrorOK retuned when everything's cool
+	ErrorOK = 0
+	// ErrorExists returned when digest exists
+	ErrorExists = 1
+	// ErrorNotFound returned as generic not found error
+	ErrorNotFound = 2
+	// ErrorNotAllowed returned as generic not allowed error
+	ErrorNotAllowed = 3
 )
 
 var (
-	ErrTryAgainLater     = errors.New("busy, try again later")
-	ErrTimestampNotFound = errors.New("timestamp not found")
+	// ErrTryAgainLater is thrown when can't upload
+	// while anchoring
+	ErrTryAgainLater = errors.New("busy, try again later")
 )
 
 // FlushRecord contains blockchain information.  This information only becomes
@@ -118,6 +123,15 @@ type GetBalanceResult struct {
 	Unconfirmed int64
 }
 
+// LastAnchorResult contains last successful anchor
+// info
+type LastAnchorResult struct {
+	ChainTimestamp int64          `json:"timestamp"` // Timestamp anchored
+	Tx             chainhash.Hash `json:"tx"`        // Tx last succcessfull anchor
+	Block          string         `json:"block"`     // Anchored tx block
+}
+
+// Backend interface
 type Backend interface {
 	// Return timestamp information for given digests.
 	Get([][sha256.Size]byte) ([]GetResult, error)
@@ -150,4 +164,7 @@ type Backend interface {
 	// GetBalance retrieves balance information for the wallet
 	// backing this instance
 	GetBalance() (*GetBalanceResult, error)
+
+	// LastAnchor retrieves last successful anchor details
+	LastAnchor() (*LastAnchorResult, error)
 }

--- a/dcrtimed/backend/filesystem/filesystem.go
+++ b/dcrtimed/backend/filesystem/filesystem.go
@@ -51,8 +51,8 @@ var (
 	// really should be automated but cron is hard.
 	//
 	// Seconds Minutes Hours Days Months DayOfWeek
-	flushSchedule = "10 * * * * *" // On the hour + 10 seconds
-	duration      = time.Minute    // Default how often we combine digests
+	flushSchedule = "10 0 * * * *" // On the hour + 10 seconds
+	duration      = time.Hour      // Default how often we combine digests
 
 	// Errors
 	errInvalidDB      = errors.New("not a database") // Should not happen

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -1158,7 +1158,8 @@ func (d *DcrtimeStore) lastAnchorV2(w http.ResponseWriter, r *http.Request) {
 	util.RespondWithJSON(w, http.StatusOK, v2.LastAnchorReply{
 		ChainTimestamp: lastAnchorResult.ChainTimestamp,
 		Transaction:    lastAnchorResult.Tx.String(),
-		Block:          lastAnchorResult.Block,
+		BlockHash:      lastAnchorResult.BlockHash,
+		BlockHeight:    lastAnchorResult.BlockHeight,
 	})
 }
 

--- a/dcrtimed/dcrtimewallet/dcrtimewallet.go
+++ b/dcrtimed/dcrtimewallet/dcrtimewallet.go
@@ -26,10 +26,11 @@ type DcrtimeWallet struct {
 	passphrase []byte
 }
 
-type Result struct {
-	Block         chainhash.Hash
+type TxLookupResult struct {
+	BlockHash     chainhash.Hash
 	Timestamp     int64
 	Confirmations int32
+	BlockHeight   int32
 }
 
 // BalanceResult contains information about the backing dcrwallet
@@ -41,7 +42,7 @@ type BalanceResult struct {
 }
 
 // Lookup looks up the provided TX hash and returns a Result structure.
-func (d *DcrtimeWallet) Lookup(tx chainhash.Hash) (*Result, error) {
+func (d *DcrtimeWallet) Lookup(tx chainhash.Hash) (*TxLookupResult, error) {
 	ctx, cancel := context.WithCancel(d.ctx)
 	defer cancel()
 
@@ -77,7 +78,7 @@ func (d *DcrtimeWallet) Lookup(tx chainhash.Hash) (*Result, error) {
 
 	// Abort early if we don't have enough confirmations.
 	if r.Confirmations[0].Confirmations <= 0 {
-		return &Result{
+		return &TxLookupResult{
 			Confirmations: r.Confirmations[0].Confirmations,
 		}, nil
 	}
@@ -95,10 +96,11 @@ func (d *DcrtimeWallet) Lookup(tx chainhash.Hash) (*Result, error) {
 		return nil, err
 	}
 
-	return &Result{
-		Block:         *block,
+	return &TxLookupResult{
+		BlockHash:     *block,
 		Timestamp:     rbi.Timestamp,
 		Confirmations: rbi.Confirmations,
+		BlockHeight:   rbi.BlockHeight,
 	}, nil
 }
 


### PR DESCRIPTION
This diff adds new call to dcrtime: `dcrtime -lastanchor`, which 
returns information about last successful anchor, such as: 
blockchain timestamp, tx id & tx block hash.

closes #66