### PR TITLE
dcrtimed: Client certs for gRPC dcrwallet changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ apitoken=sometoken
 
 ```
 
+**Note:** Dcrtimed requires access to wallet GRPC. Therefore it needs the wallet's
+server certificate to authenticate the server, as well as a local client keypair
+to authenticate the client to `dcrwallet`.  The server certificate by default
+will be found in `~/.dcrwallet/rpc.cert`, and this can be modified to another
+path using the `--walletcert` flag.  Client certs can be generated using
+[`gencerts`](https://github.com/decred/dcrd/blob/master/cmd/gencerts/) and
+`dcrtimed` will read `client.pem` and `client-key.pem` from its application
+directory by default.  The certificate (`client.pem`) must be appended to
+`~/.dcrwallet/clients.pem` in order for `dcrwallet` to trust the client.
+
 **Note:** `apitoken` key is used to access privileged http endpoints in the daemon.
 Multiple values may be provided by providing multiple apitoken values, each on
 a separate line with each line starting with "apitoken=".

--- a/dcrtimed/backend/filesystem/filesystem.go
+++ b/dcrtimed/backend/filesystem/filesystem.go
@@ -998,7 +998,7 @@ func internalNew(root string) (*FileSystem, error) {
 
 // New creates a new backend instance.  The caller should issue a Close once
 // the FileSystem backend is no longer needed.
-func New(root, cert, host string, enableCollections bool, passphrase []byte) (*FileSystem, error) {
+func New(root, cert, host, clientCert, clientKey string, enableCollections bool, passphrase []byte) (*FileSystem, error) {
 	fs, err := internalNew(root)
 	if err != nil {
 		return nil, err
@@ -1007,7 +1007,7 @@ func New(root, cert, host string, enableCollections bool, passphrase []byte) (*F
 
 	// Runtime bits
 	dcrtimewallet.UseLogger(log)
-	fs.wallet, err = dcrtimewallet.New(cert, host, passphrase)
+	fs.wallet, err = dcrtimewallet.New(cert, host, clientCert, clientKey, passphrase)
 	if err != nil {
 		return nil, err
 	}

--- a/dcrtimed/config.go
+++ b/dcrtimed/config.go
@@ -30,6 +30,9 @@ const (
 
 	defaultMainnetPort = "49152"
 	defaultTestnetPort = "59152"
+
+	walletClientCertFile = "client.pem"
+	walletClientKeyFile  = "client-key.pem"
 )
 
 var (
@@ -65,6 +68,8 @@ type config struct {
 	WalletHost        string   `long:"wallethost" description:"Hostname for wallet server"`
 	WalletCert        string   `long:"walletcert" description:"Certificate path for wallet server"`
 	WalletPassphrase  string   `long:"walletpassphrase" description:"Passphrase for wallet server"`
+	WalletClientCert  string   `long:"cert" description:"Path to TLS certificate for wallet gprc client authentication"`
+	WalletClientKey   string   `long:"key" description:"Path to TLS client authentication key for wallet gprc"`
 	Version           string
 	HTTPSCert         string   `long:"httpscert" description:"File containing the https certificate file"`
 	HTTPSKey          string   `long:"httpskey" description:"File containing the https certificate key"`
@@ -519,6 +524,14 @@ func loadConfig() (*config, []string, error) {
 		}
 
 		cfg.WalletCert = path
+	}
+
+	// Set path for the client key/cert depending on if they are set in options
+	if cfg.WalletClientCert == "" {
+		cfg.WalletClientCert = filepath.Join(cfg.HomeDir, walletClientCertFile)
+	}
+	if cfg.WalletClientKey == "" {
+		cfg.WalletClientKey = filepath.Join(cfg.HomeDir, walletClientKeyFile)
 	}
 
 	if len(cfg.StoreHost) == 0 {

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -1368,6 +1368,8 @@ func _main() error {
 		b, err := filesystem.New(loadedCfg.DataDir,
 			loadedCfg.WalletCert,
 			loadedCfg.WalletHost,
+			loadedCfg.WalletClientCert,
+			loadedCfg.WalletClientKey,
 			loadedCfg.EnableCollections,
 			[]byte(loadedCfg.WalletPassphrase))
 

--- a/dcrtimed/dcrtimewallet/dcrtimewallet.go
+++ b/dcrtimed/dcrtimewallet/dcrtimewallet.go
@@ -7,7 +7,10 @@ package dcrtimewallet
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"io/ioutil"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -191,7 +194,7 @@ func (d *DcrtimeWallet) Close() {
 }
 
 // New returns a DcrtimeWallet context.
-func New(cert, host string, passphrase []byte) (*DcrtimeWallet, error) {
+func New(cert, host, clientCert, clientKey string, passphrase []byte) (*DcrtimeWallet, error) {
 	d := &DcrtimeWallet{
 		account:    0,
 		minconf:    2,
@@ -199,10 +202,23 @@ func New(cert, host string, passphrase []byte) (*DcrtimeWallet, error) {
 		passphrase: passphrase,
 	}
 
-	creds, err := credentials.NewClientTLSFromFile(cert, "")
+	serverCAs := x509.NewCertPool()
+	serverCert, err := ioutil.ReadFile(cert)
 	if err != nil {
 		return nil, err
 	}
+	if !serverCAs.AppendCertsFromPEM(serverCert) {
+		return nil, fmt.Errorf("no certificates found in %s",
+			cert)
+	}
+	keypair, err := tls.LoadX509KeyPair(clientCert, clientKey)
+	if err != nil {
+		return nil, fmt.Errorf("read client keypair: %v", err)
+	}
+	creds := credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{keypair},
+		RootCAs:      serverCAs,
+	})
 
 	log.Infof("Wallet: %v", host)
 	d.conn, err = grpc.Dial(host, grpc.WithBlock(),


### PR DESCRIPTION
This diff allows `dcrtimed` to communicate with `dcrwallet` via gprc.

With decred/dcrwallet#1867, one must use https://github.com/decred/dcrd/tree/master/cmd/gencerts to create a fresh keypair (default: client.pem and client-key.pem) at the appdata directory of dcrtimed. Then they must also concat the content of client.pem to their clients.pem file under chosen dcrwallet appdata directory.