### PR TITLE
multi: add last-digests route to api v2

### DIFF
--- a/api/v2/api.md
+++ b/api/v2/api.md
@@ -2,11 +2,11 @@
 
 ## V2
 
-This document describes the REST API provided by a `dcrtimed` server. This API 
-allows users to create and upload hashes which are periodically submitted to 
-the Decred blockchain. It gives the option to send a single string digest, as 
-well as multiples in a array of string digests. It also provides the ability 
-to confirm the addition of the hash to a timestamped collection along with 
+This document describes the REST API provided by a `dcrtimed` server. This API
+allows users to create and upload hashes which are periodically submitted to
+the Decred blockchain. It gives the option to send a single string digest, as
+well as multiples in a array of string digests. It also provides the ability
+to confirm the addition of the hash to a timestamped collection along with
 showing and validating their inclusion in the Decred blockchain.
 
 **Methods**
@@ -16,6 +16,7 @@ showing and validating their inclusion in the Decred blockchain.
 
 - [`Timestamp`](#timestamp)
 - [`Verify`](#verify)
+- [`Last Digests`](#last-digests)
 
 **Return Codes**
 
@@ -30,9 +31,9 @@ showing and validating their inclusion in the Decred blockchain.
 
 #### `Timestamp Batch`
 
-Upload multiple digests to the time server. The server adds this 
-digest to a collection and eventually to a transaction that goes in a Decred 
-block. This method returns immediately with the collection the digest has been 
+Upload multiple digests to the time server. The server adds this
+digest to a collection and eventually to a transaction that goes in a Decred
+block. This method returns immediately with the collection the digest has been
 added to. You must use the verify call to find out when it has been anchored to
 a block (which is done in batches at a set time interval that is not related to
 the api calls).
@@ -57,7 +58,7 @@ the api calls).
 
    `id=[string]`
 
-	ID is a user provided identifier that may be used in case the client 
+	ID is a user provided identifier that may be used in case the client
 	requires a unique identifier.
 
 * **Results**
@@ -77,7 +78,7 @@ the api calls).
 
 	`results`
 
-	results is a list of integers representing the result for each digest.  
+	results is a list of integers representing the result for each digest.
 	See #Results for details on return codes.
 
 * **Example**
@@ -110,11 +111,11 @@ Reply:
 
 #### `Verify Batch`
 
-Verifies the status of a batch of digests or timestamps on the server. If 
-verifying digests, it'll return the chain information relative to that digest, 
-including its merkle path. If verifying timestamps, it'll return the 
-collection information relative to that timestamp, including all the digests 
-grouped on that collection. If it has not been anchored on the blockchain yet, 
+Verifies the status of a batch of digests or timestamps on the server. If
+verifying digests, it'll return the chain information relative to that digest,
+including its merkle path. If verifying timestamps, it'll return the
+collection information relative to that timestamp, including all the digests
+grouped on that collection. If it has not been anchored on the blockchain yet,
 it returns zero. Digests and timestamps can be verified on the same request.
 
 * **URL**
@@ -144,7 +145,7 @@ it returns zero. Digests and timestamps can be verified on the same request.
 
    `id=[string]`
 
-	ID is a user provided identifier that may be used in case the client 
+	ID is a user provided identifier that may be used in case the client
 	requires a unique identifier.
 
 * **Results**
@@ -189,7 +190,7 @@ it returns zero. Digests and timestamps can be verified on the same request.
 
 	`merklepath`
 
-	Merklepath contains additional information for the mined transaction 
+	Merklepath contains additional information for the mined transaction
 	(if available).
 
 	`timestamps`
@@ -205,7 +206,7 @@ it returns zero. Digests and timestamps can be verified on the same request.
 
 	Return code, see #Results.
 
-	`collectioninformation`	
+	`collectioninformation`
 
 	A JSON object with the information about that timestamp collection.
 
@@ -213,7 +214,7 @@ it returns zero. Digests and timestamps can be verified on the same request.
 
 	Timestamp from the server.
 
-	`transaction` 
+	`transaction`
 
 	Transaction hash that includes the digest.
 
@@ -221,9 +222,9 @@ it returns zero. Digests and timestamps can be verified on the same request.
 
 	MerkleRoot of the block containing the transaction (if mined).
 
-	`digests`	
+	`digests`
 
-	Digests contains all digests grouped and anchored on that timestamp 
+	Digests contains all digests grouped and anchored on that timestamp
 	collection.
 
 
@@ -285,7 +286,7 @@ Reply:
 
 #### `Timestamp`
 
-Upload one digest to the time server from a pure HTML form data on the client 
+Upload one digest to the time server from a pure HTML form data on the client
 side. This route exists to serve no-JS clients. Anchors the digest to the
 server the same way as batched ones.
 
@@ -309,7 +310,7 @@ server the same way as batched ones.
 
    `id=[string]`
 
-	ID is a user provided identifier that may be used in case the client 
+	ID is a user provided identifier that may be used in case the client
 	requires a unique identifier.
 
 * **Results**
@@ -347,7 +348,7 @@ Reply:
 {
     "id":"dcrtime cli",
 	"servertimestamp":1497376800,
-	"digest": 
+	"digest":
 		"d412ba345bc44fb6fbbaf2db9419b648752ecfcda6fd1aec213b45a5584d1b13",
 	"result": 1
 }
@@ -378,7 +379,7 @@ The digest was rejected because it exists. This is only relevant for the
 
 	`3`
 
-The timestamp or digest could not be found by the server. This is only 
+The timestamp or digest could not be found by the server. This is only
 relevant for the `Verify` call.
 
 * `ResultDisabled`
@@ -419,7 +420,7 @@ the same process as batched ones.
 
    `id=[string]`
 
-	ID is a user provided identifier that may be used in case the client 
+	ID is a user provided identifier that may be used in case the client
 	requires a unique identifier.
 
 * **Results**
@@ -464,7 +465,7 @@ the same process as batched ones.
 
 	`merklepath`
 
-	Merklepath contains additional information for the mined transaction 
+	Merklepath contains additional information for the mined transaction
 	(if available).
 
 	`timestamp`
@@ -480,7 +481,7 @@ the same process as batched ones.
 
 	Return code, see #Results.
 
-	`collectioninformation`	
+	`collectioninformation`
 
 	A JSON object with the information about that timestamp collection.
 
@@ -488,7 +489,7 @@ the same process as batched ones.
 
 	Timestamp from the server.
 
-	`transaction` 
+	`transaction`
 
 	Transaction hash that includes the digest.
 
@@ -496,9 +497,9 @@ the same process as batched ones.
 
 	MerkleRoot of the block containing the transaction (if mined).
 
-	`digests`	
+	`digests`
 
-	Digests contains all digests grouped and anchored on that timestamp 
+	Digests contains all digests grouped and anchored on that timestamp
 	collection.
 
 
@@ -549,5 +550,262 @@ Reply:
 			]
 		}
 	}
+}
+```
+
+#### Last Digests
+
+This method is used to ask the server the info about the last digests added. It receives a `number` as a parameter and returns an array with info about the last `number` digests in the server. **Note:** the max `number` of digests that can be queried is defined by a `maxdigestsnumber` config variable and its default value is 20.
+
+**URL:**
+
+  `/v2/last-digests`
+
+**HTTP Method:**
+
+  `POST`
+
+**Params:**
+
+| Param  |  Type  |
+| ------ | ------ |
+| number |   int  |
+
+**Results:**
+
+An array of size `number` where each value is of [Verify](#verify) type.
+
+**Example:**
+
+Request:
+
+```json
+{"number":3}
+```
+
+Reply:
+
+```json
+{
+   "digests":[
+      {
+         "digest":"2c9a1c95814f31bb8459a7f7fc3536e73354699bace060e0876966878e1d1548",
+         "servertimestamp":1668078900,
+         "result":1,
+         "chaininformation":{
+            "chaintimestamp":1668079484,
+            "transaction":"d93e0f68721569a11eb9743fdfb264207a1a9876d8615d5a9714776c1825e256",
+            "merkleroot":"08fa2aab70b371ee5bcce8ed6448e6a43a5f9e2aa614a53152cb819db3aac009",
+            "merklepath":{
+               "NumLeaves":3,
+               "Hashes":[
+                  [
+                     132,
+                     213,
+                     10,
+                     173,
+                     220,
+                     181,
+                     230,
+                     211,
+                     48,
+                     110,
+                     146,
+                     125,
+                     96,
+                     180,
+                     178,
+                     218,
+                     92,
+                     198,
+                     73,
+                     183,
+                     98,
+                     50,
+                     24,
+                     136,
+                     183,
+                     75,
+                     156,
+                     128,
+                     170,
+                     94,
+                     91,
+                     245
+                  ]
+               ],
+               "Flags":"AA=="
+            }
+         }
+      },
+      {
+         "digest":"869436ec0a37536e19161a2cd23cab04fcaf71861969af83fc13b52e79350e00",
+         "servertimestamp":1668078900,
+         "result":1,
+         "chaininformation":{
+            "chaintimestamp":1668079484,
+            "transaction":"d93e0f68721569a11eb9743fdfb264207a1a9876d8615d5a9714776c1825e256",
+            "merkleroot":"08fa2aab70b371ee5bcce8ed6448e6a43a5f9e2aa614a53152cb819db3aac009",
+            "merklepath":{
+               "NumLeaves":3,
+               "Hashes":[
+                  [
+                     132,
+                     213,
+                     10,
+                     173,
+                     220,
+                     181,
+                     230,
+                     211,
+                     48,
+                     110,
+                     146,
+                     125,
+                     96,
+                     180,
+                     178,
+                     218,
+                     92,
+                     198,
+                     73,
+                     183,
+                     98,
+                     50,
+                     24,
+                     136,
+                     183,
+                     75,
+                     156,
+                     128,
+                     170,
+                     94,
+                     91,
+                     245
+                  ]
+               ],
+               "Flags":"AA=="
+            }
+         }
+      },
+      {
+         "digest":"b074c20bd8a9e4a3bdc760fd9cf33d2417fe4489c2a1c9497ddf48bf9ed7c118",
+         "servertimestamp":1668078900,
+         "result":1,
+         "chaininformation":{
+            "chaintimestamp":1668079484,
+            "transaction":"d93e0f68721569a11eb9743fdfb264207a1a9876d8615d5a9714776c1825e256",
+            "merkleroot":"08fa2aab70b371ee5bcce8ed6448e6a43a5f9e2aa614a53152cb819db3aac009",
+            "merklepath":{
+               "NumLeaves":3,
+               "Hashes":[
+                  [
+                     176,
+                     116,
+                     194,
+                     11,
+                     216,
+                     169,
+                     228,
+                     163,
+                     189,
+                     199,
+                     96,
+                     253,
+                     156,
+                     243,
+                     61,
+                     36,
+                     23,
+                     254,
+                     68,
+                     137,
+                     194,
+                     161,
+                     201,
+                     73,
+                     125,
+                     223,
+                     72,
+                     191,
+                     158,
+                     215,
+                     193,
+                     24
+                  ],
+                  [
+                     176,
+                     116,
+                     194,
+                     11,
+                     216,
+                     169,
+                     228,
+                     163,
+                     189,
+                     199,
+                     96,
+                     253,
+                     156,
+                     243,
+                     61,
+                     36,
+                     23,
+                     254,
+                     68,
+                     137,
+                     194,
+                     161,
+                     201,
+                     73,
+                     125,
+                     223,
+                     72,
+                     191,
+                     158,
+                     215,
+                     193,
+                     24
+                  ],
+                  [
+                     176,
+                     116,
+                     194,
+                     11,
+                     216,
+                     169,
+                     228,
+                     163,
+                     189,
+                     199,
+                     96,
+                     253,
+                     156,
+                     243,
+                     61,
+                     36,
+                     23,
+                     254,
+                     68,
+                     137,
+                     194,
+                     161,
+                     201,
+                     73,
+                     125,
+                     223,
+                     72,
+                     191,
+                     158,
+                     215,
+                     193,
+                     24
+                  ]
+               ],
+               "Flags":"Pw=="
+            }
+         }
+      }
+   ]
 }
 ```

--- a/api/v2/api.md
+++ b/api/v2/api.md
@@ -555,7 +555,7 @@ Reply:
 
 #### Last Digests
 
-This method is used to ask the server the info about the last digests added. It receives a `number` as a parameter and returns an array with info about the last `number` digests in the server. **Note:** the max `number` of digests that can be queried is defined by a `maxdigestsnumber` config variable and its default value is 20.
+This method is used to ask the server the info about the last digests added. It receives a `number` as a parameter and returns an array with info about the last `number` digests in the server. **Note:** the max `number` of digests that can be queried is defined by a `maxdigests` config variable and its default value is 20.
 
 **URL:**
 

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -44,7 +44,7 @@ const (
 
 	// DefaultTestnetTimeHost indicates the default testnet time host
 	// server.
-	DefaultTestnetTimeHost = "127.0.0.1"
+	DefaultTestnetTimeHost = "time-testnet.decred.org"
 
 	// DefaultTestnetTimePort indicates the default testnet time host
 	// port.

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -88,9 +88,8 @@ var (
 	LastAnchorRoute = RoutePrefix + "/last"
 
 	// LastDigestsRoute defines the API route for retriving
-	// the last last n digests the client wants. If n is bigger
-	// than the amount of digests in the backend, it will return
-	// all the digests
+	// the last last n digests the client wants. Max n is defined
+	// via the maxdigestsnumber config option
 	LastDigestsRoute = RoutePrefix + "/last-digests"
 
 	// Result defines legible string messages to a timestamping/query

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -89,7 +89,7 @@ var (
 
 	// LastDigestsRoute defines the API route for retriving
 	// the last last n digests the client wants. Max n is defined
-	// via the maxdigestsnumber config option
+	// via the maxdigests config option
 	LastDigestsRoute = RoutePrefix + "/last-digests"
 
 	// Result defines legible string messages to a timestamping/query

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -44,7 +44,7 @@ const (
 
 	// DefaultTestnetTimeHost indicates the default testnet time host
 	// server.
-	DefaultTestnetTimeHost = "time-testnet.decred.org"
+	DefaultTestnetTimeHost = "127.0.0.1"
 
 	// DefaultTestnetTimePort indicates the default testnet time host
 	// port.
@@ -156,9 +156,9 @@ type Verify struct {
 // VerifyReply is returned by the server with the status results for the requested
 // digest and/or timestamp.
 type VerifyReply struct {
-	ID        string           `json:"id"`
-	Digest    *VerifyDigest    `json:"digest,omitempty"`
-	Timestamp *VerifyTimestamp `json:"timestamp,omitempty"`
+	ID        string          `json:"id"`
+	Digest    VerifyDigest    `json:"digest"`
+	Timestamp VerifyTimestamp `json:"timestamp"`
 }
 
 // VerifyDigest is returned by the server after verifying the status of a
@@ -213,9 +213,9 @@ type LastDigests struct {
 // VerifyBatchReply is returned by the server with the status results for the
 // requested digests and timestamps.
 type VerifyBatchReply struct {
-	ID         string             `json:"id"`
-	Digests    *[]VerifyDigest    `json:"digests,omitempty"`
-	Timestamps *[]VerifyTimestamp `json:"timestamps,omitempty"`
+	ID         string            `json:"id"`
+	Digests    []VerifyDigest    `json:"digests"`
+	Timestamps []VerifyTimestamp `json:"timestamps"`
 }
 
 // ChainInformation is returned by the server on a verify digest request.

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -87,6 +87,12 @@ var (
 	// timestamp, block height & tx id
 	LastAnchorRoute = RoutePrefix + "/last"
 
+	// LastDigestsRoute defines the API route for retriving
+	// the last last n digests the client wants. If n is bigger
+	// than the amount of digests in the backend, it will return
+	// all the digests
+	LastDigestsRoute = RoutePrefix + "/last-digests"
+
 	// Result defines legible string messages to a timestamping/query
 	// result code.
 	Result = map[ResultT]string{
@@ -150,9 +156,9 @@ type Verify struct {
 // VerifyReply is returned by the server with the status results for the requested
 // digest and/or timestamp.
 type VerifyReply struct {
-	ID        string          `json:"id"`
-	Digest    VerifyDigest    `json:"digest"`
-	Timestamp VerifyTimestamp `json:"timestamp"`
+	ID        string           `json:"id"`
+	Digest    *VerifyDigest    `json:"digest,omitempty"`
+	Timestamp *VerifyTimestamp `json:"timestamp,omitempty"`
 }
 
 // VerifyDigest is returned by the server after verifying the status of a
@@ -199,31 +205,40 @@ type VerifyBatch struct {
 	Timestamps []int64  `json:"timestamps"`
 }
 
+// LastDigests is used to ask the server the info about the N last digests
+type LastDigests struct {
+	N int32 `json:"number"`
+}
+
 // VerifyBatchReply is returned by the server with the status results for the
 // requested digests and timestamps.
 type VerifyBatchReply struct {
-	ID         string            `json:"id"`
-	Digests    []VerifyDigest    `json:"digests"`
-	Timestamps []VerifyTimestamp `json:"timestamps"`
+	ID         string             `json:"id"`
+	Digests    *[]VerifyDigest    `json:"digests,omitempty"`
+	Timestamps *[]VerifyTimestamp `json:"timestamps,omitempty"`
 }
 
 // ChainInformation is returned by the server on a verify digest request.
 // It contains the merkle path of that digest.
 type ChainInformation struct {
-	ChainTimestamp int64         `json:"chaintimestamp"`
-	Transaction    string        `json:"transaction"`
-	MerkleRoot     string        `json:"merkleroot"`
-	MerklePath     merkle.Branch `json:"merklepath"`
+	ChainTimestamp   int64         `json:"chaintimestamp"`
+	Confirmations    *int32        `json:"confirmations,omitempty"` // Using a pointer because we don't want to omit 0
+	MinConfirmations int32         `json:"minconfirmations,omitempty"`
+	Transaction      string        `json:"transaction"`
+	MerkleRoot       string        `json:"merkleroot"`
+	MerklePath       merkle.Branch `json:"merklepath"`
 }
 
 // CollectionInformation is returned by the server on a verify timestamp
 // request. It contains all digests grouped on the collection of the
 // requested block timestamp.
 type CollectionInformation struct {
-	ChainTimestamp int64    `json:"chaintimestamp"`
-	Transaction    string   `json:"transaction"`
-	MerkleRoot     string   `json:"merkleroot"`
-	Digests        []string `json:"digests"`
+	ChainTimestamp   int64    `json:"chaintimestamp"`
+	Confirmations    *int32   `json:"confirmations,omitempty"` // Using a pointer because we don't want to omit 0
+	MinConfirmations int32    `json:"minconfirmations,omitempty"`
+	Transaction      string   `json:"transaction"`
+	MerkleRoot       string   `json:"merkleroot"`
+	Digests          []string `json:"digests"`
 }
 
 // WalletBalanceReply is returned by server on a balance information of the
@@ -237,10 +252,17 @@ type WalletBalanceReply struct {
 // LastAnchorReply is returned by server on a last succcessful anchor info
 // request, it includes the id of the latest successfully broadcasted tx,
 // block hash & block height if the transaction was included in a block
-// and the chain timestamp if the tx block has more than 6 confirmations.
+// and the chain timestamp if the tx block has more than the number of
+// confirmations informed in the config file.
 type LastAnchorReply struct {
 	ChainTimestamp int64  `json:"chaintimestamp"`
 	Transaction    string `json:"transaction"`
 	BlockHash      string `json:"blockhash"`
 	BlockHeight    int32  `json:"blockheight"`
+}
+
+// LastDigestsReply is returned by server on a get last n digests
+// request, it includes a list of timestamps status results
+type LastDigestsReply struct {
+	Digests []VerifyDigest `json:"digests"`
 }

--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -391,9 +391,9 @@ func downloadV2Batch(questions []string) error {
 		return fmt.Errorf("could node decode VerifyReply: %v", err)
 	}
 
-	verifyDigests(*vbr.Digests)
+	verifyDigests(vbr.Digests)
 
-	err = verifyTimestamps(*vbr.Timestamps)
+	err = verifyTimestamps(vbr.Timestamps)
 	if err != nil {
 		return err
 	}
@@ -460,13 +460,13 @@ func downloadV2Single(question string) error {
 	// Check if a digest was sent on the request, and therefore
 	// received a non-empty reply struct.
 	if !reflect.DeepEqual(vr.Digest, v2.VerifyDigest{}) {
-		verifyDigests([]v2.VerifyDigest{*vr.Digest})
+		verifyDigests([]v2.VerifyDigest{vr.Digest})
 	}
 
 	// Check if a timestamp was sent on the request, and therefore
 	// received a non-empty reply struct.
 	if !reflect.DeepEqual(vr.Timestamp, v2.VerifyTimestamp{}) {
-		err = verifyTimestamps([]v2.VerifyTimestamp{*vr.Timestamp})
+		err = verifyTimestamps([]v2.VerifyTimestamp{vr.Timestamp})
 		if err != nil {
 			return err
 		}

--- a/cmd/dcrtime_checker/dcrtime_checker.go
+++ b/cmd/dcrtime_checker/dcrtime_checker.go
@@ -35,7 +35,7 @@ func verifyV2(digest string, fProof *os.File) error {
 	// Ensure file digest exists in the proof and that the saved answer was
 	// correct
 	found := -1
-	for k, v := range vr.Digests {
+	for k, v := range *vr.Digests {
 		if v.Digest != digest {
 			continue
 		}
@@ -46,7 +46,7 @@ func verifyV2(digest string, fProof *os.File) error {
 	if found == -1 {
 		return fmt.Errorf("file digest not found in proof")
 	}
-	v := vr.Digests[found]
+	v := (*vr.Digests)[found]
 
 	// Verify result of matching digest
 	if _, ok := v2.Result[v.Result]; !ok {
@@ -81,7 +81,7 @@ func verifyV2(digest string, fProof *os.File) error {
 
 	// Verify against dcrdata
 	err = util.VerifyAnchor(*dcrdataHost,
-		vr.Digests[found].ChainInformation.Transaction, root[:])
+		(*vr.Digests)[found].ChainInformation.Transaction, root[:])
 	if err != nil {
 		return err
 	}

--- a/cmd/dcrtime_checker/dcrtime_checker.go
+++ b/cmd/dcrtime_checker/dcrtime_checker.go
@@ -35,7 +35,7 @@ func verifyV2(digest string, fProof *os.File) error {
 	// Ensure file digest exists in the proof and that the saved answer was
 	// correct
 	found := -1
-	for k, v := range *vr.Digests {
+	for k, v := range vr.Digests {
 		if v.Digest != digest {
 			continue
 		}
@@ -46,7 +46,7 @@ func verifyV2(digest string, fProof *os.File) error {
 	if found == -1 {
 		return fmt.Errorf("file digest not found in proof")
 	}
-	v := (*vr.Digests)[found]
+	v := vr.Digests[found]
 
 	// Verify result of matching digest
 	if _, ok := v2.Result[v.Result]; !ok {
@@ -81,7 +81,7 @@ func verifyV2(digest string, fProof *os.File) error {
 
 	// Verify against dcrdata
 	err = util.VerifyAnchor(*dcrdataHost,
-		(*vr.Digests)[found].ChainInformation.Transaction, root[:])
+		vr.Digests[found].ChainInformation.Transaction, root[:])
 	if err != nil {
 		return err
 	}

--- a/dcrtimed/backend/filesystem/filesystem.go
+++ b/dcrtimed/backend/filesystem/filesystem.go
@@ -27,10 +27,9 @@ import (
 )
 
 const (
-	fStr          = "20060102.150405"
-	globalDBDir   = "global"
-	flushedKey    = "flushed"
-	confirmations = 6
+	fStr        = "20060102.150405"
+	globalDBDir = "global"
+	flushedKey  = "flushed"
 
 	// error codes that are overridden during tests only.
 	// foundGlobal is thrown if digest was found in global db
@@ -72,7 +71,8 @@ type FileSystem struct {
 	duration time.Duration // How often we combine digests
 	commit   uint          // Current version, incremented during flush
 
-	enableCollections bool // Set to true to enable collection query
+	enableCollections bool  // Set to true to enable collection query
+	confirmations     int32 // Number of confirmations to return timestamp proof
 
 	wallet *dcrtimewallet.DcrtimeWallet // Wallet context.
 
@@ -388,7 +388,7 @@ func (fs *FileSystem) lazyFlush(dbts int64, fr *backend.FlushRecord) (*dcrtimewa
 
 	if res.Confirmations == -1 {
 		return nil, errInvalidConfirmations
-	} else if res.Confirmations < confirmations {
+	} else if res.Confirmations < fs.confirmations {
 		// Return error & wallet lookup res
 		// for error handling
 		return res, errNotEnoughConfirmation
@@ -460,10 +460,11 @@ func (fs *FileSystem) getTimestamp(timestamp int64) (backend.TimestampResult, er
 
 		// Do the lazy flush, note that fr.ChainTimestamp is updated.
 		if fr.ChainTimestamp == 0 && !fs.testing {
-			_, err = fs.lazyFlush(timestamp, fr)
+			lfr, err := fs.lazyFlush(timestamp, fr)
 			if err != nil {
 				if err == errNotEnoughConfirmation {
-					// fr.ChainTimestamp == 0
+					gtme.Confirmations = &lfr.Confirmations
+					gtme.MinConfirmations = fs.confirmations
 				} else if err == errInvalidConfirmations {
 					log.Errorf("%v: Confirmations = -1",
 						fr.Tx.String())
@@ -549,10 +550,11 @@ func (fs *FileSystem) getDigest(now time.Time, current *leveldb.DB, digest [sha2
 		if fs.testing {
 			gdme.ErrorCode = foundGlobal
 		} else if gdme.AnchoredTimestamp == 0 {
-			_, err = fs.lazyFlush(dbts, fr)
+			lfr, err := fs.lazyFlush(dbts, fr)
 			if err != nil {
 				if err == errNotEnoughConfirmation {
-					// No enough confirmations.
+					gdme.Confirmations = &lfr.Confirmations
+					gdme.MinConfirmations = fs.confirmations
 				} else if err == errInvalidConfirmations {
 					log.Errorf("%v: Confirmations = -1",
 						fr.Tx.String())
@@ -561,7 +563,6 @@ func (fs *FileSystem) getDigest(now time.Time, current *leveldb.DB, digest [sha2
 					return gdme, err
 				}
 			}
-
 			gdme.AnchoredTimestamp = fr.ChainTimestamp
 		}
 
@@ -746,6 +747,79 @@ func (fs *FileSystem) GetTimestamps(timestamps []int64) ([]backend.TimestampResu
 	}
 
 	return gtmes, nil
+}
+
+// Get the last n digests in the added to the Backend
+func (fs *FileSystem) LastDigests(n int32) ([]backend.GetResult, error) {
+	files, err := ioutil.ReadDir(fs.root)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]backend.GetResult, 0)
+
+	// Reverse slice so we look at the most recent files first
+	for i, j := 0, len(files)-1; i < j; i, j = i+1, j-1 {
+		files[i], files[j] = files[j], files[i]
+	}
+
+	// Loop through files and use the getTimestamp function to get info about
+	// the digests in each folder
+	for _, fi := range files {
+		if len(results) >= int(n) {
+			break
+		}
+		if !fi.IsDir() {
+			return nil, fmt.Errorf("Unexpected file %v",
+				filepath.Join(fs.root, fi.Name()))
+		}
+
+		// We can skip global
+		if fi.Name() != "global" {
+			// Ensure it is a valid timestamp
+			t, err := time.Parse(fStr, fi.Name())
+			if err != nil {
+				return nil, fmt.Errorf("invalid timestamp: %v", fi.Name())
+			}
+
+			log.Debugf("--- Checking: %v (%v)\n", fi.Name(),
+				t.Unix())
+
+			res, err := fs.getTimestamp(t.Unix())
+			if err != nil {
+				return nil, err
+			}
+
+			// Convert array of digests to array of pointers to digests so we
+			// can pass as a pram to merkle.AuthPath and get the MerklePath
+			ptDigests := make([]*[sha256.Size]byte, 0, len(res.Digests))
+			for _, d := range res.Digests {
+				ptDigests = append(ptDigests, &d)
+			}
+			for _, digest := range res.Digests {
+				gdme := backend.GetResult{
+					Digest:            digest,
+					Timestamp:         res.Timestamp,
+					ErrorCode:         res.ErrorCode,
+					Confirmations:     res.Confirmations,
+					MinConfirmations:  res.MinConfirmations,
+					AnchoredTimestamp: res.AnchoredTimestamp,
+					Tx:                res.Tx,
+					MerkleRoot:        res.MerkleRoot,
+					MerklePath:        *merkle.AuthPath(ptDigests, &digest),
+				}
+				results = append(results, gdme)
+				if len(results) >= int(n) {
+					break
+				}
+			}
+
+			log.Debugf("=== Finished: %v (%v)\n", fi.Name(),
+				t.Unix())
+		}
+	}
+
+	return results, nil
 }
 
 // Put is a required interface function.  In our case it stores the provided
@@ -1056,12 +1130,13 @@ func internalNew(root string) (*FileSystem, error) {
 
 // New creates a new backend instance.  The caller should issue a Close once
 // the FileSystem backend is no longer needed.
-func New(root, cert, host, clientCert, clientKey string, enableCollections bool, passphrase []byte) (*FileSystem, error) {
+func New(root, cert, host, clientCert, clientKey string, enableCollections bool, confirmations int32, passphrase []byte) (*FileSystem, error) {
 	fs, err := internalNew(root)
 	if err != nil {
 		return nil, err
 	}
 	fs.enableCollections = enableCollections
+	fs.confirmations = confirmations
 
 	// Runtime bits
 	dcrtimewallet.UseLogger(log)

--- a/dcrtimed/backend/filesystem/filesystem.go
+++ b/dcrtimed/backend/filesystem/filesystem.go
@@ -756,18 +756,17 @@ func (fs *FileSystem) LastDigests(n int32) ([]backend.GetResult, error) {
 		return nil, fmt.Errorf("Invalid number %d of digests requested. Max is: %d", n, fs.maxDigests)
 	}
 
-	// We need to be read locked from here on out.
-	fs.RLock()
-	defer fs.RUnlock()
-
-	files, err := os.ReadDir(fs.root)
-	if err != nil {
-		return nil, err
-	}
-
 	results := make([]backend.GetResult, 0)
 
 	if fs.enableCollections {
+		// We need to be read locked from here on out.
+		fs.RLock()
+		defer fs.RUnlock()
+
+		files, err := os.ReadDir(fs.root)
+		if err != nil {
+			return nil, err
+		}
 		// Loop through files and use the getTimestamp function to get info about
 		// the digests in each folder
 		for i := len(files) - 1; i >= 0; i-- {

--- a/dcrtimed/backend/filesystem/fsck.go
+++ b/dcrtimed/backend/filesystem/fsck.go
@@ -129,8 +129,7 @@ func journal(filename, action string, payload interface{}) error {
 //
 // 3.1 Verify merkle against flushRecord merkle
 // 3.2 Ensure that all digests in the database exist in the global database and
-//
-//	the timestamps matches the global timestamp directory.
+// the timestamps matches the global timestamp directory.
 //
 // 3.3 Verify that the flushRecord timestamp exists on the blockchain.
 func (fs *FileSystem) fsckTimestamp(options *backend.FsckOptions, ts int64, empties map[int64]struct{}) error {

--- a/dcrtimed/config.go
+++ b/dcrtimed/config.go
@@ -36,14 +36,15 @@ const (
 )
 
 var (
-	defaultHomeDir       = dcrutil.AppDataDir("dcrtimed", false)
-	defaultConfigFile    = filepath.Join(defaultHomeDir, defaultConfigFilename)
-	defaultDataDir       = filepath.Join(defaultHomeDir, defaultDataDirname)
-	defaultHTTPSKeyFile  = filepath.Join(defaultHomeDir, "https.key")
-	defaultHTTPSCertFile = filepath.Join(defaultHomeDir, "https.cert")
-	defaultLogDir        = filepath.Join(defaultHomeDir, defaultLogDirname)
-	defaultAPIVersions   = fmt.Sprintf("%v,%v", v1.APIVersion, v2.APIVersion)
-	defaultConfirmations = 6
+	defaultHomeDir          = dcrutil.AppDataDir("dcrtimed", false)
+	defaultConfigFile       = filepath.Join(defaultHomeDir, defaultConfigFilename)
+	defaultDataDir          = filepath.Join(defaultHomeDir, defaultDataDirname)
+	defaultHTTPSKeyFile     = filepath.Join(defaultHomeDir, "https.key")
+	defaultHTTPSCertFile    = filepath.Join(defaultHomeDir, "https.cert")
+	defaultLogDir           = filepath.Join(defaultHomeDir, defaultLogDirname)
+	defaultAPIVersions      = fmt.Sprintf("%v,%v", v1.APIVersion, v2.APIVersion)
+	defaultConfirmations    = 6
+	defaultMaxDigestsNumber = 20
 )
 
 // runServiceCommand is only set to a real function on Windows.  It is used
@@ -78,6 +79,7 @@ type config struct {
 	StoreCert         string   `long:"storecert" description:"File containing the https certificate file for storehost."`
 	EnableCollections bool     `long:"enablecollections" description:"Allow clients to query collection timestamps."`
 	Confirmations     int32    `long:"confirmations" description:"Amount of confirmations necessary to return timestamp proof."`
+	MaxDigestsNumber  int32    `long:"maxdigestsnumber" description:"Amount of confirmations necessary to return timestamp proof."`
 	APITokens         []string `long:"apitoken" description:"Token used to grant access to privileged API resources."`
 	APIVersions       string   `long:"apiversions" description:"Enables API versions on the daemon."`
 }
@@ -276,16 +278,17 @@ func parseAndValidateAPIVersions(vs string) ([]uint, error) {
 func loadConfig() (*config, []string, error) {
 	// Default config.
 	cfg := config{
-		HomeDir:       defaultHomeDir,
-		ConfigFile:    defaultConfigFile,
-		DebugLevel:    defaultLogLevel,
-		DataDir:       defaultDataDir,
-		LogDir:        defaultLogDir,
-		HTTPSKey:      defaultHTTPSKeyFile,
-		HTTPSCert:     defaultHTTPSCertFile,
-		Version:       version(),
-		APIVersions:   defaultAPIVersions,
-		Confirmations: int32(defaultConfirmations),
+		HomeDir:          defaultHomeDir,
+		ConfigFile:       defaultConfigFile,
+		DebugLevel:       defaultLogLevel,
+		DataDir:          defaultDataDir,
+		LogDir:           defaultLogDir,
+		HTTPSKey:         defaultHTTPSKeyFile,
+		HTTPSCert:        defaultHTTPSCertFile,
+		Version:          version(),
+		APIVersions:      defaultAPIVersions,
+		Confirmations:    int32(defaultConfirmations),
+		MaxDigestsNumber: int32(defaultMaxDigestsNumber),
 	}
 
 	// Service options which are only added on Windows.

--- a/dcrtimed/config.go
+++ b/dcrtimed/config.go
@@ -36,15 +36,15 @@ const (
 )
 
 var (
-	defaultHomeDir          = dcrutil.AppDataDir("dcrtimed", false)
-	defaultConfigFile       = filepath.Join(defaultHomeDir, defaultConfigFilename)
-	defaultDataDir          = filepath.Join(defaultHomeDir, defaultDataDirname)
-	defaultHTTPSKeyFile     = filepath.Join(defaultHomeDir, "https.key")
-	defaultHTTPSCertFile    = filepath.Join(defaultHomeDir, "https.cert")
-	defaultLogDir           = filepath.Join(defaultHomeDir, defaultLogDirname)
-	defaultAPIVersions      = fmt.Sprintf("%v,%v", v1.APIVersion, v2.APIVersion)
-	defaultConfirmations    = 6
-	defaultMaxDigestsNumber = 20
+	defaultHomeDir       = dcrutil.AppDataDir("dcrtimed", false)
+	defaultConfigFile    = filepath.Join(defaultHomeDir, defaultConfigFilename)
+	defaultDataDir       = filepath.Join(defaultHomeDir, defaultDataDirname)
+	defaultHTTPSKeyFile  = filepath.Join(defaultHomeDir, "https.key")
+	defaultHTTPSCertFile = filepath.Join(defaultHomeDir, "https.cert")
+	defaultLogDir        = filepath.Join(defaultHomeDir, defaultLogDirname)
+	defaultAPIVersions   = fmt.Sprintf("%v,%v", v1.APIVersion, v2.APIVersion)
+	defaultConfirmations = 6
+	defaultMaxDigests    = 20
 )
 
 // runServiceCommand is only set to a real function on Windows.  It is used
@@ -79,7 +79,7 @@ type config struct {
 	StoreCert         string   `long:"storecert" description:"File containing the https certificate file for storehost."`
 	EnableCollections bool     `long:"enablecollections" description:"Allow clients to query collection timestamps."`
 	Confirmations     int32    `long:"confirmations" description:"Amount of confirmations necessary to return timestamp proof."`
-	MaxDigestsNumber  int32    `long:"maxdigestsnumber" description:"Amount of confirmations necessary to return timestamp proof."`
+	MaxDigests        int32    `long:"maxdigests" description:"Max number of digests that can be queried"`
 	APITokens         []string `long:"apitoken" description:"Token used to grant access to privileged API resources."`
 	APIVersions       string   `long:"apiversions" description:"Enables API versions on the daemon."`
 }
@@ -278,17 +278,17 @@ func parseAndValidateAPIVersions(vs string) ([]uint, error) {
 func loadConfig() (*config, []string, error) {
 	// Default config.
 	cfg := config{
-		HomeDir:          defaultHomeDir,
-		ConfigFile:       defaultConfigFile,
-		DebugLevel:       defaultLogLevel,
-		DataDir:          defaultDataDir,
-		LogDir:           defaultLogDir,
-		HTTPSKey:         defaultHTTPSKeyFile,
-		HTTPSCert:        defaultHTTPSCertFile,
-		Version:          version(),
-		APIVersions:      defaultAPIVersions,
-		Confirmations:    int32(defaultConfirmations),
-		MaxDigestsNumber: int32(defaultMaxDigestsNumber),
+		HomeDir:       defaultHomeDir,
+		ConfigFile:    defaultConfigFile,
+		DebugLevel:    defaultLogLevel,
+		DataDir:       defaultDataDir,
+		LogDir:        defaultLogDir,
+		HTTPSKey:      defaultHTTPSKeyFile,
+		HTTPSCert:     defaultHTTPSCertFile,
+		Version:       version(),
+		APIVersions:   defaultAPIVersions,
+		Confirmations: int32(defaultConfirmations),
+		MaxDigests:    int32(defaultMaxDigests),
 	}
 
 	// Service options which are only added on Windows.

--- a/dcrtimed/config.go
+++ b/dcrtimed/config.go
@@ -43,6 +43,7 @@ var (
 	defaultHTTPSCertFile = filepath.Join(defaultHomeDir, "https.cert")
 	defaultLogDir        = filepath.Join(defaultHomeDir, defaultLogDirname)
 	defaultAPIVersions   = fmt.Sprintf("%v,%v", v1.APIVersion, v2.APIVersion)
+	defaultConfirmations = 6
 )
 
 // runServiceCommand is only set to a real function on Windows.  It is used
@@ -53,31 +54,32 @@ var runServiceCommand func(string) error
 //
 // See loadConfig for details on the configuration load process.
 type config struct {
-	HomeDir           string   `short:"A" long:"appdata" description:"Path to application home directory"`
-	ShowVersion       bool     `short:"V" long:"version" description:"Display version information and exit"`
-	ConfigFile        string   `short:"C" long:"configfile" description:"Path to configuration file"`
-	DataDir           string   `short:"b" long:"datadir" description:"Directory to store data"`
+	HomeDir           string   `short:"A" long:"appdata" description:"Path to application home directory."`
+	ShowVersion       bool     `short:"V" long:"version" description:"Display version information and exit."`
+	ConfigFile        string   `short:"C" long:"configfile" description:"Path to configuration file."`
+	DataDir           string   `short:"b" long:"datadir" description:"Directory to store data."`
 	LogDir            string   `long:"logdir" description:"Directory to log output."`
-	TestNet           bool     `long:"testnet" description:"Use the test network"`
-	SimNet            bool     `long:"simnet" description:"Use the simulation test network"`
-	Profile           string   `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
-	CPUProfile        string   `long:"cpuprofile" description:"Write CPU profile to the specified file"`
-	MemProfile        string   `long:"memprofile" description:"Write mem profile to the specified file"`
-	DebugLevel        string   `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
-	Listeners         []string `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 49152, testnet: 59152)"`
-	WalletHost        string   `long:"wallethost" description:"Hostname for wallet server"`
-	WalletCert        string   `long:"walletcert" description:"Certificate path for wallet server"`
-	WalletPassphrase  string   `long:"walletpassphrase" description:"Passphrase for wallet server"`
-	WalletClientCert  string   `long:"cert" description:"Path to TLS certificate for wallet gprc client authentication"`
-	WalletClientKey   string   `long:"key" description:"Path to TLS client authentication key for wallet gprc"`
+	TestNet           bool     `long:"testnet" description:"Use the test network."`
+	SimNet            bool     `long:"simnet" description:"Use the simulation test network."`
+	Profile           string   `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536."`
+	CPUProfile        string   `long:"cpuprofile" description:"Write CPU profile to the specified file."`
+	MemProfile        string   `long:"memprofile" description:"Write mem profile to the specified file."`
+	DebugLevel        string   `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems."`
+	Listeners         []string `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 49152, testnet: 59152)."`
+	WalletHost        string   `long:"wallethost" description:"Hostname for wallet server."`
+	WalletCert        string   `long:"walletcert" description:"Certificate path for wallet server."`
+	WalletPassphrase  string   `long:"walletpassphrase" description:"Passphrase for wallet server."`
+	WalletClientCert  string   `long:"cert" description:"Path to TLS certificate for wallet gprc client authentication."`
+	WalletClientKey   string   `long:"key" description:"Path to TLS client authentication key for wallet gprc."`
 	Version           string
-	HTTPSCert         string   `long:"httpscert" description:"File containing the https certificate file"`
-	HTTPSKey          string   `long:"httpskey" description:"File containing the https certificate key"`
-	StoreHost         string   `long:"storehost" description:"Enable proxy mode - send requests to the specified ip:port"`
-	StoreCert         string   `long:"storecert" description:"File containing the https certificate file for storehost"`
+	HTTPSCert         string   `long:"httpscert" description:"File containing the https certificate file."`
+	HTTPSKey          string   `long:"httpskey" description:"File containing the https certificate key."`
+	StoreHost         string   `long:"storehost" description:"Enable proxy mode - send requests to the specified ip:port."`
+	StoreCert         string   `long:"storecert" description:"File containing the https certificate file for storehost."`
 	EnableCollections bool     `long:"enablecollections" description:"Allow clients to query collection timestamps."`
-	APITokens         []string `long:"apitoken" description:"Token used to grant access to privileged API resources"`
-	APIVersions       string   `long:"apiversions" description:"Enables API versions on the daemon"`
+	Confirmations     int32    `long:"confirmations" description:"Amount of confirmations necessary to return timestamp proof."`
+	APITokens         []string `long:"apitoken" description:"Token used to grant access to privileged API resources."`
+	APIVersions       string   `long:"apiversions" description:"Enables API versions on the daemon."`
 }
 
 // serviceOptions defines the configuration options for the daemon as a service
@@ -274,15 +276,16 @@ func parseAndValidateAPIVersions(vs string) ([]uint, error) {
 func loadConfig() (*config, []string, error) {
 	// Default config.
 	cfg := config{
-		HomeDir:     defaultHomeDir,
-		ConfigFile:  defaultConfigFile,
-		DebugLevel:  defaultLogLevel,
-		DataDir:     defaultDataDir,
-		LogDir:      defaultLogDir,
-		HTTPSKey:    defaultHTTPSKeyFile,
-		HTTPSCert:   defaultHTTPSCertFile,
-		Version:     version(),
-		APIVersions: defaultAPIVersions,
+		HomeDir:       defaultHomeDir,
+		ConfigFile:    defaultConfigFile,
+		DebugLevel:    defaultLogLevel,
+		DataDir:       defaultDataDir,
+		LogDir:        defaultLogDir,
+		HTTPSKey:      defaultHTTPSKeyFile,
+		HTTPSCert:     defaultHTTPSCertFile,
+		Version:       version(),
+		APIVersions:   defaultAPIVersions,
+		Confirmations: int32(defaultConfirmations),
 	}
 
 	// Service options which are only added on Windows.

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -315,6 +315,30 @@ func (d *DcrtimeStore) proxyLastAnchorV2(w http.ResponseWriter, r *http.Request)
 	log.Infof("%v LastAnchor %v", r.URL.Path, r.RemoteAddr)
 }
 
+func (d *DcrtimeStore) proxyLastDigestsV2Route(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		util.RespondWithError(w, http.StatusBadRequest,
+			"Unable to read request")
+		return
+	}
+
+	var ld v2.LastDigests
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&ld); err != nil {
+		util.RespondWithError(w, http.StatusBadRequest,
+			"Invalid request payload")
+		return
+	}
+	d.sendToBackend(r.Context(), w, r.Method, v2.VerifyBatchRoute, r.Header.Get("Content-Type"),
+		r.RemoteAddr, bytes.NewReader(b))
+
+	log.Infof("%v Last Digests %v: Number",
+		r.URL.Path, r.RemoteAddr, ld.N)
+}
+
 // version returns the supported API versions running on the server.
 // Handles /version
 func (d *DcrtimeStore) version(w http.ResponseWriter, r *http.Request) {
@@ -826,9 +850,11 @@ func (d *DcrtimeStore) verifyBatchV2(w http.ResponseWriter, r *http.Request) {
 		vt := v2.VerifyTimestamp{
 			ServerTimestamp: ts.Timestamp,
 			CollectionInformation: v2.CollectionInformation{
-				ChainTimestamp: ts.AnchoredTimestamp,
-				Transaction:    ts.Tx.String(),
-				MerkleRoot:     hex.EncodeToString(ts.MerkleRoot[:]),
+				ChainTimestamp:   ts.AnchoredTimestamp,
+				Confirmations:    ts.Confirmations,
+				MinConfirmations: ts.MinConfirmations,
+				Transaction:      ts.Tx.String(),
+				MerkleRoot:       hex.EncodeToString(ts.MerkleRoot[:]),
 			},
 			Result: -1,
 		}
@@ -889,10 +915,12 @@ func (d *DcrtimeStore) verifyBatchV2(w http.ResponseWriter, r *http.Request) {
 			Digest:          hex.EncodeToString(dr.Digest[:]),
 			ServerTimestamp: dr.Timestamp,
 			ChainInformation: v2.ChainInformation{
-				ChainTimestamp: dr.AnchoredTimestamp,
-				Transaction:    dr.Tx.String(),
-				MerkleRoot:     hex.EncodeToString(dr.MerkleRoot[:]),
-				MerklePath:     dr.MerklePath,
+				Confirmations:    dr.Confirmations,
+				MinConfirmations: dr.MinConfirmations,
+				ChainTimestamp:   dr.AnchoredTimestamp,
+				Transaction:      dr.Tx.String(),
+				MerkleRoot:       hex.EncodeToString(dr.MerkleRoot[:]),
+				MerklePath:       dr.MerklePath,
 			},
 			Result: -1,
 		}
@@ -921,8 +949,8 @@ func (d *DcrtimeStore) verifyBatchV2(w http.ResponseWriter, r *http.Request) {
 
 	util.RespondWithJSON(w, http.StatusOK, v2.VerifyBatchReply{
 		ID:         v.ID,
-		Timestamps: tsReply,
-		Digests:    dReply,
+		Timestamps: &tsReply,
+		Digests:    &dReply,
 	})
 }
 
@@ -1070,15 +1098,17 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Translate timestamp result.
-	var tsReply v2.VerifyTimestamp
+	var tsReply *v2.VerifyTimestamp = nil
 	if len(tsr) != 0 {
 		ts := tsr[len(tsr)-1]
 		vt := v2.VerifyTimestamp{
 			ServerTimestamp: ts.Timestamp,
 			CollectionInformation: v2.CollectionInformation{
-				ChainTimestamp: ts.AnchoredTimestamp,
-				Transaction:    ts.Tx.String(),
-				MerkleRoot:     hex.EncodeToString(ts.MerkleRoot[:]),
+				ChainTimestamp:   ts.AnchoredTimestamp,
+				Confirmations:    ts.Confirmations,
+				MinConfirmations: ts.MinConfirmations,
+				Transaction:      ts.Tx.String(),
+				MerkleRoot:       hex.EncodeToString(ts.MerkleRoot[:]),
 			},
 			Result: -1,
 		}
@@ -1114,7 +1144,7 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 					hex.EncodeToString(digest[:]))
 		}
 
-		tsReply = vt
+		tsReply = &vt
 	}
 
 	// Digest.
@@ -1133,17 +1163,19 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Translate digest results.
-	var dReply v2.VerifyDigest
+	var dReply *v2.VerifyDigest = nil
 	if len(drs) != 0 {
 		dr := drs[len(drs)-1]
 		vd := v2.VerifyDigest{
 			Digest:          hex.EncodeToString(dr.Digest[:]),
 			ServerTimestamp: dr.Timestamp,
 			ChainInformation: v2.ChainInformation{
-				ChainTimestamp: dr.AnchoredTimestamp,
-				Transaction:    dr.Tx.String(),
-				MerkleRoot:     hex.EncodeToString(dr.MerkleRoot[:]),
-				MerklePath:     dr.MerklePath,
+				Confirmations:    dr.Confirmations,
+				MinConfirmations: dr.MinConfirmations,
+				ChainTimestamp:   dr.AnchoredTimestamp,
+				Transaction:      dr.Tx.String(),
+				MerkleRoot:       hex.EncodeToString(dr.MerkleRoot[:]),
+				MerklePath:       dr.MerklePath,
 			},
 			Result: -1,
 		}
@@ -1167,7 +1199,7 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 					errorCode))
 			return
 		}
-		dReply = vd
+		dReply = &vd
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, v2.VerifyReply{
@@ -1198,6 +1230,77 @@ func (d *DcrtimeStore) lastAnchorV2(w http.ResponseWriter, r *http.Request) {
 		Transaction:    lastAnchorResult.Tx.String(),
 		BlockHash:      lastAnchorResult.BlockHash,
 		BlockHeight:    lastAnchorResult.BlockHeight,
+	})
+}
+
+func (d *DcrtimeStore) lastDigestsV2(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	var ld v2.LastDigests
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&ld); err != nil {
+		util.RespondWithError(w, http.StatusBadRequest,
+			"Invalid request payload")
+		return
+	}
+
+	log.Infof("%v LastDigests %v", r.URL.Path, r.RemoteAddr)
+
+	ldr, err := d.backend.LastDigests(ld.N)
+	if err != nil {
+		errorCode := time.Now().Unix()
+
+		log.Errorf("%v LastDigests error code %v: %v",
+			r.RemoteAddr, errorCode, err)
+		util.RespondWithError(w, http.StatusInternalServerError,
+			fmt.Sprintf("failed to retrieve latest %d digests info, "+
+				"contact administrator and provide "+
+				"the following error code: %v", ld.N, errorCode))
+		return
+	}
+
+	vdReply := make([]v2.VerifyDigest, 0, len(ldr))
+	for _, vr := range ldr {
+		vd := v2.VerifyDigest{
+			Digest:          hex.EncodeToString(vr.Digest[:]),
+			ServerTimestamp: vr.Timestamp,
+			ChainInformation: v2.ChainInformation{
+				ChainTimestamp:   vr.AnchoredTimestamp,
+				Confirmations:    vr.Confirmations,
+				MinConfirmations: vr.MinConfirmations,
+				Transaction:      vr.Tx.String(),
+				MerkleRoot:       hex.EncodeToString(vr.MerkleRoot[:]),
+				MerklePath:       vr.MerklePath,
+			},
+			Result: -1,
+		}
+
+		switch vr.ErrorCode {
+		case backend.ErrorOK:
+			vd.Result = v2.ResultOK
+		case backend.ErrorNotFound:
+			vd.Result = v2.ResultDoesntExistError
+		}
+
+		if vd.Result == -1 {
+			// Generic internal error.
+			errorCode := time.Now().Unix()
+			log.Errorf("%v digest ErrorCode translation error "+
+				"code %v: %v", r.RemoteAddr, errorCode, err)
+
+			util.RespondWithError(w, http.StatusInternalServerError,
+				fmt.Sprintf("Could not retrieve last %d digests, "+
+					"contact administrator and provide "+
+					"the following error code: %v",
+					ld.N, errorCode))
+			return
+		}
+		vdReply = append(vdReply, vd)
+	}
+
+	util.RespondWithJSON(w, http.StatusOK, v2.LastDigestsReply{
+		Digests: vdReply,
 	})
 }
 
@@ -1385,6 +1488,7 @@ func _main() error {
 			loadedCfg.WalletClientCert,
 			loadedCfg.WalletClientKey,
 			loadedCfg.EnableCollections,
+			loadedCfg.Confirmations,
 			[]byte(loadedCfg.WalletPassphrase))
 
 		if err != nil {
@@ -1412,6 +1516,7 @@ func _main() error {
 	var verifyV2Route func(http.ResponseWriter, *http.Request)
 	var walletBalanceV2Route http.HandlerFunc
 	var lastAnchorV2Route http.HandlerFunc
+	var lastDigestsV2Route func(http.ResponseWriter, *http.Request)
 
 	if certPool != nil {
 		// PROXY ENABLED
@@ -1436,6 +1541,7 @@ func _main() error {
 		verifyV2Route = d.proxyVerifyV2
 		walletBalanceV2Route = d.proxyWalletBalanceV2
 		lastAnchorV2Route = d.proxyLastAnchorV2
+		lastDigestsV2Route = d.proxyLastDigestsV2Route
 	} else {
 		statusV1Route = d.statusV1
 		timestampV1Route = d.timestampV1
@@ -1450,6 +1556,7 @@ func _main() error {
 		verifyV2Route = d.verifyV2
 		walletBalanceV2Route = d.walletBalanceV2
 		lastAnchorV2Route = d.lastAnchorV2
+		lastDigestsV2Route = d.lastDigestsV2
 	}
 
 	// Top-level route handler
@@ -1474,6 +1581,7 @@ func _main() error {
 			d.addRoute(http.MethodPost, v2.VerifyBatchRoute, verifyBatchV2Route)
 			d.addRoute(http.MethodGet, v2.WalletBalanceRoute, walletBalanceV2Route)
 			d.addRoute(http.MethodGet, v2.LastAnchorRoute, lastAnchorV2Route)
+			d.addRoute(http.MethodPost, v2.LastDigestsRoute, lastDigestsV2Route)
 			d.router.HandleFunc(v2.TimestampRoute, timestampV2Route).Methods(http.MethodPost, http.MethodGet)
 			d.router.HandleFunc(v2.VerifyRoute, verifyV2Route).Methods(http.MethodPost, http.MethodGet)
 		}

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -949,8 +949,8 @@ func (d *DcrtimeStore) verifyBatchV2(w http.ResponseWriter, r *http.Request) {
 
 	util.RespondWithJSON(w, http.StatusOK, v2.VerifyBatchReply{
 		ID:         v.ID,
-		Timestamps: &tsReply,
-		Digests:    &dReply,
+		Timestamps: tsReply,
+		Digests:    dReply,
 	})
 }
 
@@ -1098,7 +1098,7 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Translate timestamp result.
-	var tsReply *v2.VerifyTimestamp = nil
+	var tsReply v2.VerifyTimestamp
 	if len(tsr) != 0 {
 		ts := tsr[len(tsr)-1]
 		vt := v2.VerifyTimestamp{
@@ -1144,7 +1144,7 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 					hex.EncodeToString(digest[:]))
 		}
 
-		tsReply = &vt
+		tsReply = vt
 	}
 
 	// Digest.
@@ -1163,7 +1163,7 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Translate digest results.
-	var dReply *v2.VerifyDigest = nil
+	var dReply v2.VerifyDigest
 	if len(drs) != 0 {
 		dr := drs[len(drs)-1]
 		vd := v2.VerifyDigest{
@@ -1199,7 +1199,7 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 					errorCode))
 			return
 		}
-		dReply = &vd
+		dReply = vd
 	}
 
 	util.RespondWithJSON(w, http.StatusOK, v2.VerifyReply{

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -333,9 +333,9 @@ func (d *DcrtimeStore) proxyLastDigestsV2Route(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if ld.N > d.cfg.MaxDigestsNumber {
+	if ld.N > d.cfg.MaxDigests {
 		util.RespondWithError(w, http.StatusUnprocessableEntity,
-			fmt.Sprintf("Invalid number %d of digests requested. Max is: %d", ld.N, d.cfg.MaxDigestsNumber))
+			fmt.Sprintf("Invalid number %d of digests requested. Max is: %d", ld.N, d.cfg.MaxDigests))
 		return
 	}
 
@@ -1252,9 +1252,9 @@ func (d *DcrtimeStore) lastDigestsV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if ld.N > d.cfg.MaxDigestsNumber {
+	if ld.N > d.cfg.MaxDigests {
 		util.RespondWithError(w, http.StatusUnprocessableEntity,
-			fmt.Sprintf("Invalid number %d of digests requested. Max is: %d", ld.N, d.cfg.MaxDigestsNumber))
+			fmt.Sprintf("Invalid number %d of digests requested. Max is: %d", ld.N, d.cfg.MaxDigests))
 		return
 	}
 
@@ -1501,7 +1501,7 @@ func _main() error {
 			loadedCfg.WalletClientKey,
 			loadedCfg.EnableCollections,
 			loadedCfg.Confirmations,
-			loadedCfg.MaxDigestsNumber,
+			loadedCfg.MaxDigests,
 			[]byte(loadedCfg.WalletPassphrase))
 
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/jrick/logrotate v1.0.0
 	github.com/robfig/cron v1.2.0
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
+	golang.org/x/sys v0.1.0 // indirect
 	google.golang.org/grpc v1.32.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,9 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
Depends on: https://github.com/decred/dcrtime/pull/81

**This PR:**

- Add Confirmations config option. This is the minimum amount of confirmations required to return the ChainTimestamp. Default is 6.   

- Add MaxDigests config option. This is the max amount of digests that can be queried. Default is 20.   

- Return Confirmations and MinConfirmations when the digest is flushed but we still doesn’t have the Blockchain proof ready (ChainTimestamp != 0) for digests in the Verify request.

- ~Omit empty structs from the Verify request. When a Verify request is made only with digests, omit the TimestampsReply struct and when a Verify request is made only with timestamps, omit the DigestReply struct.~

- Add `/last-digests` route to api/v2. This route receives a `number` as parameter and returns the last `number` digests added to the backend (anchored or not).

**Obs**: `/last-digests` make use of the `getTimestamp func` to query the collections. In order to use this endpoint the `enablecollections` config option should be set to true, otherwise it will return an empty array.

https://github.com/decred/dcrtime/blob/bbebe6df45a8c650c4e605d778494480b056f121/dcrtimed/backend/filesystem/filesystem.go#L424

**TODO**

- [x] Add `/last-digests` to the api/v2 documentation