### PR TITLE
api/v2: Duplicate merkle branch definition

### DIFF
--- a/api/v2/go.mod
+++ b/api/v2/go.mod
@@ -1,3 +1,3 @@
 module github.com/decred/dcrtime/api/v2
 
-go 1.13
+go 1.17

--- a/api/v2/v2.go
+++ b/api/v2/v2.go
@@ -5,10 +5,9 @@
 package v2
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"regexp"
-
-	"github.com/decred/dcrtime/merkle"
 )
 
 type ResultT int
@@ -217,15 +216,23 @@ type VerifyBatchReply struct {
 	Timestamps []VerifyTimestamp `json:"timestamps"`
 }
 
+// MerkleBranch shares the same struct definition as merkle.Branch.
+// This has known horrible JSON marshaling in /v2.
+type MerkleBranch struct {
+	NumLeaves uint32              // Nuber of leaves
+	Hashes    [][sha256.Size]byte // Merkle branch
+	Flags     []byte              // Bitmap of merkle tree
+}
+
 // ChainInformation is returned by the server on a verify digest request.
 // It contains the merkle path of that digest.
 type ChainInformation struct {
-	ChainTimestamp   int64         `json:"chaintimestamp"`
-	Confirmations    *int32        `json:"confirmations,omitempty"` // Using a pointer because we don't want to omit 0
-	MinConfirmations int32         `json:"minconfirmations,omitempty"`
-	Transaction      string        `json:"transaction"`
-	MerkleRoot       string        `json:"merkleroot"`
-	MerklePath       merkle.Branch `json:"merklepath"`
+	ChainTimestamp   int64        `json:"chaintimestamp"`
+	Confirmations    *int32       `json:"confirmations,omitempty"` // Using a pointer because we don't want to omit 0
+	MinConfirmations int32        `json:"minconfirmations,omitempty"`
+	Transaction      string       `json:"transaction"`
+	MerkleRoot       string       `json:"merkleroot"`
+	MerklePath       MerkleBranch `json:"merklepath"`
 }
 
 // CollectionInformation is returned by the server on a verify timestamp

--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -410,7 +410,7 @@ func verifyDigests(vd []v2.VerifyDigest) {
 		}
 
 		// Verify merkle path.
-		root, err := merkle.VerifyAuthPath(&d.ChainInformation.MerklePath)
+		root, err := merkle.VerifyAuthPath((*merkle.Branch)(&d.ChainInformation.MerklePath))
 		if err != nil {
 			if err != merkle.ErrEmpty {
 				fmt.Printf("%v invalid auth path %v\n",

--- a/cmd/dcrtime_checker/dcrtime_checker.go
+++ b/cmd/dcrtime_checker/dcrtime_checker.go
@@ -55,7 +55,7 @@ func verifyV2(digest string, fProof *os.File) error {
 	}
 
 	// Verify merkle path.
-	root, err := merkle.VerifyAuthPath(&v.ChainInformation.MerklePath)
+	root, err := merkle.VerifyAuthPath((*merkle.Branch)(&v.ChainInformation.MerklePath))
 	if err != nil {
 		if err != merkle.ErrEmpty {
 			return fmt.Errorf("%v invalid auth path %v",

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -927,7 +927,7 @@ func (d *DcrtimeStore) verifyBatchV2(w http.ResponseWriter, r *http.Request) {
 				ChainTimestamp:   dr.AnchoredTimestamp,
 				Transaction:      dr.Tx.String(),
 				MerkleRoot:       hex.EncodeToString(dr.MerkleRoot[:]),
-				MerklePath:       dr.MerklePath,
+				MerklePath:       v2.MerkleBranch(dr.MerklePath),
 			},
 			Result: -1,
 		}
@@ -1182,7 +1182,7 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 				ChainTimestamp:   dr.AnchoredTimestamp,
 				Transaction:      dr.Tx.String(),
 				MerkleRoot:       hex.EncodeToString(dr.MerkleRoot[:]),
-				MerklePath:       dr.MerklePath,
+				MerklePath:       v2.MerkleBranch(dr.MerklePath),
 			},
 			Result: -1,
 		}
@@ -1283,7 +1283,7 @@ func (d *DcrtimeStore) lastDigestsV2(w http.ResponseWriter, r *http.Request) {
 				MinConfirmations: vr.MinConfirmations,
 				Transaction:      vr.Tx.String(),
 				MerkleRoot:       hex.EncodeToString(vr.MerkleRoot[:]),
-				MerklePath:       vr.MerklePath,
+				MerklePath:       v2.MerkleBranch(vr.MerklePath),
 			},
 			Result: -1,
 		}


### PR DESCRIPTION
This removes the dependency on the main module's merkle package.

The JSON marshaling of the merkle branch is disgusting but this would need to be cleaned up in a v3 API if anyone attempts this.

Part of a larger change to make actually make the api/v2 submodule actually go-gettable.  It is completely busted at the moment, due to importing the main module's merkle package without a require on the main module.