### PR TITLE
Add flushtimestamp to verify digest & timestamp.

### DIFF
--- a/cmd/dcrtime/dcrtime.go
+++ b/cmd/dcrtime/dcrtime.go
@@ -443,6 +443,8 @@ func verifyDigests(vd []v2.VerifyDigest) {
 			d.ChainInformation.ChainTimestamp)
 		fmt.Printf("  %-16v: %v\n", "Server Timestamp",
 			d.ServerTimestamp)
+		fmt.Printf("  %-16v: %v\n", "Flush Timestamp",
+			d.FlushTimestamp)
 		fmt.Printf("  %-16v: %v\n", "Merkle Root",
 			d.ChainInformation.MerkleRoot)
 		fmt.Printf("  %-16v: %v\n", "TxID",
@@ -497,6 +499,10 @@ func verifyTimestamps(vt []v2.VerifyTimestamp) error {
 			fmt.Printf("  %-15v: %v\n", prefix, digest)
 			prefix = ""
 		}
+
+		// Print flush time
+		fmt.Printf("  %-15v: %v\n", "Flush Timestamp",
+			t.FlushTimestamp)
 
 		// Only print additional info if we are anchored
 		if t.CollectionInformation.ChainTimestamp == 0 {

--- a/dcrtimed/backend/backend.go
+++ b/dcrtimed/backend/backend.go
@@ -52,9 +52,10 @@ type PutResult struct {
 	ErrorCode uint
 }
 
-// TimestampResult is a cooked error returned by the backend.
+// TimestampResult is a cooked response returned by the backend.
 type TimestampResult struct {
 	Timestamp         int64               // Collection timestamp
+	FlushTimestamp    int64               // Flush timestamp
 	ErrorCode         uint                // Overall result
 	Confirmations     *int32              // Tx confirmations
 	MinConfirmations  int32               // Mininum number of confirmations to return timestamp proof
@@ -72,6 +73,7 @@ type GetResult struct {
 	Confirmations     *int32            // Tx confirmations
 	MinConfirmations  int32             // Mininum number of confirmations to return timestamp proof
 	AnchoredTimestamp int64             // Anchored timestamp
+	FlushTimestamp    int64             // Flush timestamp
 	Tx                chainhash.Hash    // Anchor Tx
 	MerkleRoot        [sha256.Size]byte // Merkle root
 	MerklePath        merkle.Branch     // Auth path

--- a/dcrtimed/backend/filesystem/filesystem.go
+++ b/dcrtimed/backend/filesystem/filesystem.go
@@ -477,6 +477,7 @@ func (fs *FileSystem) getTimestamp(timestamp int64) (backend.TimestampResult, er
 		}
 
 		gtme.AnchoredTimestamp = fr.ChainTimestamp
+		gtme.FlushTimestamp = fr.FlushTimestamp
 
 		return gtme, nil
 	}
@@ -546,6 +547,7 @@ func (fs *FileSystem) getDigest(now time.Time, current *leveldb.DB, digest [sha2
 		// That pointer better not be nil!
 		gdme.MerklePath = *merkle.AuthPath(fr.Hashes, &digest)
 		gdme.Timestamp = fr.ServerTimestamp
+		gdme.FlushTimestamp = fr.FlushTimestamp
 
 		// Override error code during testing
 		if fs.testing {

--- a/dcrtimed/backend/filesystem/filesystem_test.go
+++ b/dcrtimed/backend/filesystem/filesystem_test.go
@@ -188,6 +188,10 @@ func TestGetDigests(t *testing.T) {
 			t.Fatalf("server timmestamp should be the directory timestamp, want %d got %d",
 				timestamp, gr.Timestamp)
 		}
+		// Ensure the flush timestamp is set
+		if gr.ErrorCode == 0 && gr.FlushTimestamp == 0 {
+			t.Fatalf("expected flush timestamp to be set, got 0")
+		}
 	}
 }
 
@@ -445,6 +449,10 @@ func TestGetTimestamp(t *testing.T) {
 	}
 	if len(exists) != count {
 		t.Fatalf("expected %v exists got %v", count, len(exists))
+	}
+	// Ensure flush timestamp is set
+	if gtme.FlushTimestamp == 0 {
+		t.Fatalf("expected flush timestamp to be set, got 0")
 	}
 }
 

--- a/dcrtimed/dcrtimed.go
+++ b/dcrtimed/dcrtimed.go
@@ -849,6 +849,7 @@ func (d *DcrtimeStore) verifyBatchV2(w http.ResponseWriter, r *http.Request) {
 	for _, ts := range tsr {
 		vt := v2.VerifyTimestamp{
 			ServerTimestamp: ts.Timestamp,
+			FlushTimestamp:  ts.FlushTimestamp,
 			CollectionInformation: v2.CollectionInformation{
 				ChainTimestamp:   ts.AnchoredTimestamp,
 				Confirmations:    ts.Confirmations,
@@ -913,6 +914,7 @@ func (d *DcrtimeStore) verifyBatchV2(w http.ResponseWriter, r *http.Request) {
 		vd := v2.VerifyDigest{
 			Digest:          hex.EncodeToString(dr.Digest[:]),
 			ServerTimestamp: dr.Timestamp,
+			FlushTimestamp:  dr.FlushTimestamp,
 			ChainInformation: v2.ChainInformation{
 				Confirmations:    dr.Confirmations,
 				MinConfirmations: dr.MinConfirmations,
@@ -1102,6 +1104,7 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 		ts := tsr[len(tsr)-1]
 		vt := v2.VerifyTimestamp{
 			ServerTimestamp: ts.Timestamp,
+			FlushTimestamp:  ts.FlushTimestamp,
 			CollectionInformation: v2.CollectionInformation{
 				ChainTimestamp:   ts.AnchoredTimestamp,
 				Confirmations:    ts.Confirmations,
@@ -1167,6 +1170,7 @@ func (d *DcrtimeStore) verifyV2(w http.ResponseWriter, r *http.Request) {
 		vd := v2.VerifyDigest{
 			Digest:          hex.EncodeToString(dr.Digest[:]),
 			ServerTimestamp: dr.Timestamp,
+			FlushTimestamp:  dr.FlushTimestamp,
 			ChainInformation: v2.ChainInformation{
 				Confirmations:    dr.Confirmations,
 				MinConfirmations: dr.MinConfirmations,

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/decred/dcrd/txscript/v4 v4.1.0
 	github.com/decred/dcrd/wire v1.6.0
 	github.com/decred/dcrdata/api/types/v5 v5.0.1
-	github.com/decred/dcrtime/api/v2 v2.0.0
+	github.com/decred/dcrtime/api/v2 v2.1.0
 	github.com/decred/slog v1.2.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/decred/dcrdata/semver v1.0.0 h1:DBqYU/x+4LqHq/3r4xKdF6xG5ewktG2KDC+g/
 github.com/decred/dcrdata/semver v1.0.0/go.mod h1:z+nQqiAd9fYkHhBLbejysZ2FPHtgkrErWDgMf+JlZWE=
 github.com/decred/dcrdata/txhelpers/v4 v4.0.1 h1:jNPPSP5HzE4cfddj5zIJhrIEus/Tvd28Xvl/uVGjrMI=
 github.com/decred/dcrdata/txhelpers/v4 v4.0.1/go.mod h1:cUJbgsIzzI42llHDS0nkPlG49vPJ0cW6IZGbfu5sFrA=
-github.com/decred/dcrtime/api/v2 v2.0.0 h1:UB2CBvQslooQc22YF6Bqf/yTMwfxva+DOi2s7bEoJ18=
-github.com/decred/dcrtime/api/v2 v2.0.0/go.mod h1:WJshmls13ONj+9KaBwvjGIDsg/NDZa7SLWTb2foYhRc=
+github.com/decred/dcrtime/api/v2 v2.1.0 h1:zS8VsVsSzfgQvenT4Ta93eC5LGAVVcf8Wl0JXzQJoRk=
+github.com/decred/dcrtime/api/v2 v2.1.0/go.mod h1:WJshmls13ONj+9KaBwvjGIDsg/NDZa7SLWTb2foYhRc=
 github.com/decred/dcrwallet/rpc/jsonrpc/types v1.3.0 h1:yCxtFqK7X6GvZWQzHXjCwoGCy9YVe3tGEwxCjW5rYQk=
 github.com/decred/dcrwallet/rpc/jsonrpc/types v1.3.0/go.mod h1:Xvekb43GtfMiRbyIY4ZJ9Uhd9HRIAcnp46f3q2eIExU=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=


### PR DESCRIPTION
This commit populates the `FlushTimestamp` on the backend's `FlushRecord`,
and returns it in the verify digest and verify timestamp calls.

Closes #100 