### PR TITLE
dcrtime_dumpdb: Default to dumping JSON

### DIFF
--- a/cmd/dcrtime_dumpdb/dcrtime_dumpdb.go
+++ b/cmd/dcrtime_dumpdb/dcrtime_dumpdb.go
@@ -15,8 +15,8 @@ var (
 	defaultHomeDir = dcrutil.AppDataDir("dcrtimed", false)
 
 	destination = flag.String("destination", "", "Restore destination")
-	dumpJSON    = flag.Bool("json", false, "Dump JSON")
-	restore     = flag.Bool("restore", false, "Restore backend, -destination is required")
+	dumpJSON    = flag.Bool("json", true, "Dump JSON")
+	restore     = flag.Bool("restore", false, "Restore backend from JSON dump, -destination is required")
 	fsRoot      = flag.String("source", "", "Source directory")
 	testnet     = flag.Bool("testnet", false, "Use testnet port")
 )


### PR DESCRIPTION
Restoring requires the JSON dump, so default to dumping to JSON.

Use -json=false to dump human readable output.